### PR TITLE
feat(ovn-central) Add ovn-central-controller

### DIFF
--- a/charts/kube-ovn-v2/templates/_helpers.tpl
+++ b/charts/kube-ovn-v2/templates/_helpers.tpl
@@ -103,7 +103,11 @@ Uses Exists operator for empty/nil-value labels and In for specific values.
 Number of master nodes
 */}}
 {{- define "kubeovn.nodeCount" -}}
-  {{- len (split "," ((join "," .Values.masterNodes) | default (include "kubeovn.nodeIPs" .))) }}
+  {{- if .Values.nodeCount -}}
+    {{- .Values.nodeCount }}
+  {{- else -}}
+    {{- min 3 (len (split "," ((join "," .Values.masterNodes) | default (include "kubeovn.nodeIPs" .)))) }}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/kube-ovn-v2/templates/central/central-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $centralImage := include "kubeovn.imageSpec" (dict "root" . "image" .Values.central.image) | fromYaml -}}
-kind: {{ ternary "StatefulSet" "Deployment" .Values.central.hcp.enabled }}
+kind: {{ ternary "StatefulSet" "Deployment" (or .Values.central.hcp.enabled .Values.central.dynamicPeers.enabled) }}
 apiVersion: apps/v1
 metadata:
   name: ovn-central
@@ -20,8 +20,15 @@ spec:
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Delete
     whenScaled: Delete
+  {{- else if .Values.central.dynamicPeers.enabled }}
+  serviceName: ovn-central
+  podManagementPolicy: Parallel
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   {{- end }}
-  {{- if not .Values.central.hcp.enabled }}
+  {{- if not (or .Values.central.hcp.enabled .Values.central.dynamicPeers.enabled) }}
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -57,7 +64,8 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
       affinity:
-        {{- include "kube-ovn.affinities.nodeAffinity" (dict "hardcodedRequired" (ternary (list) (include "kubeovn.masterNodeRequired" . | fromYamlArray) .Values.central.hcp.enabled) "userPreferred" .Values.central.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.central.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) | nindent 8 }}
+        {{- $clusterIDPreferred := list (dict "matchExpressions" (list (dict "key" "kube-ovn.io/ovn-nb-cluster-id" "operator" "Exists")) "weight" 100) -}}
+        {{- include "kube-ovn.affinities.nodeAffinity" (dict "hardcodedPreferred" (ternary $clusterIDPreferred (list) .Values.central.dynamicPeers.enabled) "hardcodedRequired" (ternary (list) (include "kubeovn.masterNodeRequired" . | fromYamlArray) .Values.central.hcp.enabled) "userPreferred" .Values.central.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution "userRequired" .Values.central.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution) | nindent 8 }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -113,6 +121,36 @@ spec:
                 - SYS_NICE
           env:
 {{- include "kubeovn.ovnCentralTLSEnv" . | nindent 12 }}
+            {{- if .Values.central.dynamicPeers.enabled }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DYNAMIC_PEERS
+              value: "{{ .Values.central.dynamicPeers.enabled | default false }}"
+            - name: DYNAMIC_JOIN_TIMEOUT
+              value: "{{ .Values.central.dynamicPeers.joinTimeout | default 30 }}"
+            - name: DEAD_MEMBER_TIMEOUT
+              value: "{{ .Values.central.dynamicPeers.deadMemberTimeout | default 120 }}"
+            - name: NO_LEADER_TIMEOUT
+              value: "{{ .Values.central.dynamicPeers.noLeaderTimeout | default 30 }}"
+            - name: STALE_STUB_TIMEOUT
+              value: "{{ .Values.central.dynamicPeers.staleStubTimeout | default 120 }}"
+            - name: BACKUP_INTERVAL
+              value: "{{ .Values.central.dynamicPeers.backupInterval | default 60 }}"
+            - name: COMPACT_INTERVAL
+              value: "{{ .Values.central.dynamicPeers.compactInterval | default 300 }}"
+            - name: OVSDB_CRASH_TIMEOUT
+              value: "{{ .Values.central.dynamicPeers.ovsdbCrashTimeout | default 30 }}"
+            - name: OVSDB_STUCK_TIMEOUT
+              value: "{{ .Values.central.dynamicPeers.ovsdbStuckTimeout | default 180 }}"
+            - name: BOOTSTRAP_LEASE_DURATION
+              value: "{{ .Values.central.dynamicPeers.bootstrapLeaseDuration | default 600 }}"
+            - name: BOOTSTRAP_RENEW_DEADLINE
+              value: "{{ .Values.central.dynamicPeers.bootstrapRenewDeadline | default 300 }}"
+            - name: RECONVERT_TIMEOUT
+              value: "{{ .Values.central.dynamicPeers.reconvertTimeout | default 300 }}"
+            {{- end }}
             {{- if .Values.central.hcp.enabled }}
             - name: POD_NAME
               valueFrom:
@@ -184,6 +222,25 @@ spec:
             {{- end }}
             - mountPath: /var/run/tls
               name: kube-ovn-tls
+          {{- if .Values.central.dynamicPeers.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - /kube-ovn/ovn-central-controller-readiness.sh
+            periodSeconds: {{ .Values.central.dynamicPeers.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ .Values.central.dynamicPeers.readinessProbe.timeoutSeconds | default 10 }}
+            failureThreshold: {{ .Values.central.dynamicPeers.readinessProbe.failureThreshold | default 3 }}
+          livenessProbe:
+            exec:
+              command:
+                - bash
+                - /kube-ovn/ovn-central-controller-liveness.sh
+            initialDelaySeconds: {{ .Values.central.dynamicPeers.livenessProbe.initialDelaySeconds | default 120 }}
+            periodSeconds: {{ .Values.central.dynamicPeers.livenessProbe.periodSeconds | default 30 }}
+            timeoutSeconds: {{ .Values.central.dynamicPeers.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.central.dynamicPeers.livenessProbe.failureThreshold | default 5 }}
+          {{- else }}
           readinessProbe:
             exec:
               command:
@@ -200,6 +257,7 @@ spec:
             periodSeconds: 15
             failureThreshold: 10
             timeoutSeconds: 45
+          {{- end }}
       nodeSelector:
         kubernetes.io/os: "linux"
         {{- if not .Values.central.hcp.enabled }}

--- a/charts/kube-ovn-v2/templates/central/central-headless-service.yaml
+++ b/charts/kube-ovn-v2/templates/central/central-headless-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.central.dynamicPeers.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: ovn-central
+  namespace: {{ .Values.namespace }}
+  {{- with .Values.central.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.central.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: ovn-central
+    app.kubernetes.io/part-of: kube-ovn
+    kube-ovn.io/ovn-status: active
+{{- end }}

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -219,7 +219,7 @@ spec:
               value: "{{ include "kubeovn.ovnNbAddress" . }}"
             - name: OVN_SB_ADDR
               value: "{{ include "kubeovn.ovnSbAddress" . }}"
-            {{- else }}
+            {{- else if not .Values.central.dynamicPeers.enabled }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnDbAddresses" . }}"
             {{- end }}

--- a/charts/kube-ovn-v2/templates/hooks/upgrade-ovs-ovn.yaml
+++ b/charts/kube-ovn-v2/templates/hooks/upgrade-ovs-ovn.yaml
@@ -45,6 +45,7 @@ rules:
       - apps
     resources:
       - deployments
+      - statefulsets
     resourceNames:
       - ovn-central
     verbs:
@@ -149,6 +150,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: OVN_CENTRAL_KIND
+              value: {{ if or .Values.central.hcp.enabled .Values.central.dynamicPeers.enabled }}statefulset{{ else }}deployment{{ end }}
           command:
             - bash
             - -eo

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-daemonset.yaml
@@ -144,7 +144,7 @@ spec:
             {{- if .Values.central.hcp.enabled }}
             - name: OVN_SB_ADDR
               value: "{{ include "kubeovn.ovnSbAddress" . }}"
-            {{- else }}
+            {{- else if not .Values.central.dynamicPeers.enabled }}
             - name: OVN_DB_IPS
               value: "{{ include "kubeovn.ovnDbAddresses" . }}"
             {{- end }}

--- a/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
+++ b/charts/kube-ovn-v2/templates/ovs-ovn/ovs-ovn-dpdk-daemonset.yaml
@@ -81,9 +81,9 @@ spec:
             {{- if .Values.central.hcp.enabled }}
             - name: OVN_SB_ADDR
               value: "{{ include "kubeovn.ovnSbAddress" . }}"
-            {{- else }}
+            {{- else if not .Values.central.dynamicPeers.enabled }}
             - name: OVN_DB_IPS
-              value: "{{ include "kubeovn.masterNodes" . | default (include "kubeovn.nodeIPs" .) }}"
+              value: "{{ include "kubeovn.ovnDbAddresses" . }}"
             {{- end }}
             - name: OVN_REMOTE_PROBE_INTERVAL
               value: "{{ .Values.ovsOvn.ovnRemoteProbeInterval }}"

--- a/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
+++ b/charts/kube-ovn-v2/templates/rbac/ovn-CR.yaml
@@ -325,6 +325,22 @@ rules:
       - pods
     verbs:
       - get
+      - list
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
       - patch
   - apiGroups:
       - ""

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -36,6 +36,18 @@ clusterDomain: cluster.local
 # If not specified, fallback to auto-identifying masters based on "masterNodesLabels"
 # @section -- Global parameters
 masterNodes: []
+# -- Override the replica/quorum count for ovn-central and kube-ovn-controller.
+# Set explicitly when DYNAMIC_PEERS=true (node IPs are not known at render time).
+# Falls back to auto-counting masterNodes / nodeIPs when unset.
+# @section -- Global parameters
+nodeCount: ""
+# -- DNS hostname of the OVN Northbound DB endpoint. When set, takes priority over masterNodes/masterNodesLabels.
+# Use for external endpoints where NB and SB are on different services (no square brackets in the connection string).
+# @section -- Global parameters
+ovnNbHost: ""
+# -- DNS hostname of the OVN Southbound DB endpoint. When set, takes priority over masterNodes/masterNodesLabels.
+# @section -- Global parameters
+ovnSbHost: ""
 # -- Label used to auto-identify masters.
 # Any node that has any of these labels will be considered a master node.
 # Note: This feature uses Helm "lookup" function, which is not compatible with tools such as ArgoCD.
@@ -1114,6 +1126,67 @@ central:
   # -- ""
   # @section -- OVN-central daemon configuration.
   ovnLeaderProbeInterval: 5
+
+  # -- ovn-central-controller settings: dynamic peer discovery, in-process raft
+  # recovery, and leader-checker replacement.
+  # @section -- OVN-central daemon configuration.
+  dynamicPeers:
+    # -- Enable the ovn-central-controller binary. Switches the readiness probe
+    # to ovn-central-controller-readiness.sh.
+    # @section -- OVN-central daemon configuration.
+    enabled: false
+    # -- Seconds the ovn-central-controller waits for cluster_member + leader
+    # during bring-up before falling into recovery.
+    # @section -- OVN-central daemon configuration.
+    joinTimeout: 30
+    # -- Seconds without last_msg from a peer before ovn-central-controller kicks it.
+    # @section -- OVN-central daemon configuration.
+    deadMemberTimeout: 120
+    # -- Seconds with no raft leader before in-process recovery is triggered.
+    # @section -- OVN-central daemon configuration.
+    noLeaderTimeout: 30
+    # -- Seconds before a not-joined join-stub on disk is wiped during preflight.
+    # @section -- OVN-central daemon configuration.
+    staleStubTimeout: 120
+    # -- Seconds between db-raft-header backups.
+    # @section -- OVN-central daemon configuration.
+    backupInterval: 60
+    # -- Seconds between ovsdb-server/compact invocations on the leader.
+    # @section -- OVN-central daemon configuration.
+    compactInterval: 300
+    # -- Seconds the controller tolerates a missing ovs-appctl socket before
+    # exiting fatal (kubelet then restarts the pod).
+    # @section -- OVN-central daemon configuration.
+    ovsdbCrashTimeout: 30
+    # -- Seconds the heartbeat goroutine tolerates "ovsdb not active" OUTSIDE
+    # recovery before halting heartbeats (liveness probe then fires).
+    # @section -- OVN-central daemon configuration.
+    ovsdbStuckTimeout: 180
+    # -- Seconds the bootstrap raft lease is held. Must comfortably exceed
+    # the worst-case reconvert (cluster-to-standalone on multi-GB DBs).
+    # @section -- OVN-central daemon configuration.
+    bootstrapLeaseDuration: 600
+    # -- Seconds before the bootstrap raft lease must be renewed.
+    # @section -- OVN-central daemon configuration.
+    bootstrapRenewDeadline: 300
+    # -- Seconds allotted to ovsdb-tool cluster-to-standalone during reconvert.
+    # @section -- OVN-central daemon configuration.
+    reconvertTimeout: 300
+    # -- Tunables for the readiness probe (ovn-central-controller).
+    # @section -- OVN-central daemon configuration.
+    readinessProbe:
+      periodSeconds: 5
+      timeoutSeconds: 10
+      failureThreshold: 3
+    # -- Tunables for the liveness probe. failureThreshold *
+    # periodSeconds = how long a stale heartbeat is tolerated before kubelet
+    # kills the pod. Default 5*30s=150s (≤3 min including probe latency).
+    # @section -- OVN-central daemon configuration.
+    livenessProbe:
+      initialDelaySeconds: 120
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 5
 
 
 # -- Configuration for the OVN interconnection (IC) controller.

--- a/cmd/cmdmain.go
+++ b/cmd/cmdmain.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/kubeovn/kube-ovn/cmd/frr"
+	"github.com/kubeovn/kube-ovn/cmd/ovn_central_controller"
 	"github.com/kubeovn/kube-ovn/cmd/ovn_ic_controller"
 	"github.com/kubeovn/kube-ovn/cmd/ovn_leader_checker"
 	"github.com/kubeovn/kube-ovn/cmd/ovn_monitor"
@@ -15,11 +16,12 @@ import (
 )
 
 const (
-	CmdMonitor          = "kube-ovn-monitor"
-	CmdSpeaker          = "kube-ovn-speaker"
-	CmdWebhook          = "kube-ovn-webhook"
-	CmdOvnLeaderChecker = "kube-ovn-leader-checker"
-	CmdOvnICController  = "kube-ovn-ic-controller"
+	CmdMonitor              = "kube-ovn-monitor"
+	CmdSpeaker              = "kube-ovn-speaker"
+	CmdWebhook              = "kube-ovn-webhook"
+	CmdOvnLeaderChecker     = "kube-ovn-leader-checker"
+	CmdOvnICController      = "kube-ovn-ic-controller"
+	CmdOvnCentralController = "ovn-central-controller"
 )
 
 func main() {
@@ -42,6 +44,8 @@ func main() {
 		ovn_leader_checker.CmdMain()
 	case CmdOvnICController:
 		ovn_ic_controller.CmdMain()
+	case CmdOvnCentralController:
+		ovn_central_controller.CmdMain()
 	default:
 		util.LogFatalAndExit(nil, "%s is an unknown command", cmd)
 	}

--- a/cmd/ovn_central_controller/ovn_central_controller.go
+++ b/cmd/ovn_central_controller/ovn_central_controller.go
@@ -1,0 +1,12 @@
+package ovn_central_controller
+
+import (
+	"github.com/kubeovn/kube-ovn/pkg/ovn_central_controller"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func CmdMain() {
+	if err := ovn_central_controller.Run(); err != nil {
+		util.LogFatalAndExit(err, "ovn-central-controller failed")
+	}
+}

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -19,6 +19,7 @@ RUN ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-monitor && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-leader-checker && \
     ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/kube-ovn-ic-controller && \
     ln -s /kube-ovn/kube-ovn /kube-ovn/kube-ovn-acl-sample && \
+    ln -s /kube-ovn/kube-ovn-cmd /kube-ovn/ovn-central-controller && \
     ln -s /kube-ovn/kube-ovn-controller /kube-ovn/kube-ovn-pinger && \
     setcap CAP_NET_BIND_SERVICE+eip /kube-ovn/kube-ovn-cmd && \
     setcap CAP_NET_RAW,CAP_NET_BIND_SERVICE+eip /kube-ovn/kube-ovn-controller && \

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -7578,6 +7578,22 @@ rules:
       - pods
     verbs:
       - get
+      - list
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
       - patch
   - apiGroups:
       - ""

--- a/dist/images/ovn-central-controller-liveness.sh
+++ b/dist/images/ovn-central-controller-liveness.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Liveness probe for ovn-central-controller (DYNAMIC_PEERS mode).
+#
+# The controller runs a dedicated goroutine that touches HEARTBEAT_FILE
+# every ~5s, independent of the orchestration loop. The goroutine also
+# self-suspends touches when ovsdb has been unhealthy past the
+# OvsdbStuckTimeout / BootstrapLeaseDuration threshold (see startHeartbeat).
+#
+# A stale heartbeat file therefore signals one of:
+#   - Go runtime hung (deadlock, frozen goroutines, OOM-spin).
+#   - ovsdb-server unhealthy for >3 min outside recovery.
+#   - recoverCluster() stuck >10 min (legitimate reconvert ceiling).
+#
+# Distinct from readiness, which only reflects "fully working cluster
+# member": readiness drops legitimately during recovery and recovery is
+# itself bounded by heartbeat-staleness rather than by readiness.
+
+set -u
+
+HEARTBEAT_FILE=${HEARTBEAT_FILE:-/var/run/ovn/ovn-central-controller.alive}
+HEARTBEAT_STALE_THRESHOLD_SEC=${HEARTBEAT_STALE_THRESHOLD_SEC:-30}
+
+if [[ ! -f "$HEARTBEAT_FILE" ]]; then
+    # File hasn't been written yet. initialDelaySeconds on the probe
+    # absorbs the cold-start window.
+    echo "heartbeat file missing: $HEARTBEAT_FILE" >&2
+    exit 1
+fi
+
+now=$(date +%s)
+mtime=$(stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$((now - mtime))
+if (( age > HEARTBEAT_STALE_THRESHOLD_SEC )); then
+    echo "heartbeat stale: age=${age}s threshold=${HEARTBEAT_STALE_THRESHOLD_SEC}s" >&2
+    exit 1
+fi
+exit 0

--- a/dist/images/ovn-central-controller-readiness.sh
+++ b/dist/images/ovn-central-controller-readiness.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Readiness probe for ovn-central in DYNAMIC_PEERS mode.
+#
+# Returns 0 only when BOTH NB and SB ovsdb report:
+#   Status: cluster member
+#   Leader: <known sid> (not "unknown")
+#   AND we have committed data: role=leader OR Log range non-trivial
+#   (logHigh > logLow, meaning leader replicated AppendEntries to us).
+#
+# Other pods' ovn-central-controller treats Pod.Ready=true as the
+# trustworthy "this peer is in a working cluster" signal, so the probe
+# must NOT pass on a stub that ovsdb-server is reporting cluster_member
+# optimistically while AddServer is still mid-flight. Without the log
+# check, stub-only pods would briefly pass readiness, peers would treat
+# them as authoritative, and we'd lose data via case-1 wipe-rejoin.
+
+set -u
+
+check_db() {
+    local sock=$1 name=$2 out leader role lo hi
+    if ! out=$(ovs-appctl -t "$sock" cluster/status "$name" 2>/dev/null); then
+        return 1
+    fi
+    grep -q '^Status: cluster member' <<<"$out" || return 1
+    leader=$(awk '/^Leader:/ {print $2; exit}' <<<"$out")
+    [[ -n "$leader" && "$leader" != "unknown" ]] || return 1
+    role=$(awk '/^Role:/ {print $2; exit}' <<<"$out")
+    if [[ "$role" == "leader" ]]; then
+        return 0  # leader's log is committed by definition
+    fi
+    # Follower: ensure Log range shows committed entries beyond the
+    # initial stub. "Log: [N, M]" -- need M > N. Use -F so we work
+    # under BusyBox awk (no gawk match()-with-array extension).
+    read -r lo hi < <(awk -F'[][, ]+' '/^Log:/ {print $2, $3; exit}' <<<"$out")
+    [[ -n "$lo" && -n "$hi" && "$hi" -gt "$lo" ]]
+}
+
+check_db /var/run/ovn/ovnnb_db.ctl OVN_Northbound || exit 1
+check_db /var/run/ovn/ovnsb_db.ctl OVN_Southbound || exit 1
+exit 0

--- a/dist/images/ovs-healthcheck.sh
+++ b/dist/images/ovs-healthcheck.sh
@@ -3,10 +3,18 @@ set -euo pipefail
 shopt -s expand_aliases
 
 OVN_DB_IPS=${OVN_DB_IPS:-}
+OVN_SB_HOST=${OVN_SB_HOST:-}
 ENABLE_SSL=${ENABLE_SSL:-false}
 
 function gen_conn_str {
-  if [[ -z "${OVN_DB_IPS}" ]]; then
+  local port=$1
+  if [[ -n "${OVN_SB_HOST}" ]]; then
+    if [[ "$ENABLE_SSL" == "false" ]]; then
+      x="tcp:${OVN_SB_HOST}:${port}"
+    else
+      x="ssl:${OVN_SB_HOST}:${port}"
+    fi
+  elif [[ -z "${OVN_DB_IPS}" ]]; then
     if [[ "$ENABLE_SSL" == "false" ]]; then
       x="tcp:[${OVN_SB_SERVICE_HOST}]:${OVN_SB_SERVICE_PORT}"
     else
@@ -15,9 +23,9 @@ function gen_conn_str {
   else
     t=$(echo -n "${OVN_DB_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-      x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "tcp:[$i]:${port}",; done | sed 's/,$//')
     else
-      x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "ssl:[$i]:${port}",; done | sed 's/,$//')
     fi
   fi
   echo "$x"

--- a/dist/images/start-controller.sh
+++ b/dist/images/start-controller.sh
@@ -8,10 +8,25 @@ OVN_SB_ADDR=${OVN_SB_ADDR:-}
 # externally-exposed ovn-central whose NodePort/LoadBalancer remaps ports.
 KUBE_OVN_NB_PORT=${KUBE_OVN_NB_PORT:-6641}
 KUBE_OVN_SB_PORT=${KUBE_OVN_SB_PORT:-6642}
+OVN_NB_HOST=${OVN_NB_HOST:-}
+OVN_SB_HOST=${OVN_SB_HOST:-}
 
 function gen_conn_str {
-  if [[ -z "${OVN_DB_IPS}" ]]; then
-    if [[ "$1" == "$KUBE_OVN_NB_PORT" ]]; then
+  local port=$1
+  local db_host
+  if [[ "${port}" == "${KUBE_OVN_NB_PORT}" ]]; then
+    db_host="${OVN_NB_HOST}"
+  else
+    db_host="${OVN_SB_HOST}"
+  fi
+  if [[ -n "${db_host}" ]]; then
+    if [[ "$ENABLE_SSL" == "false" ]]; then
+      x="tcp:${db_host}:${port}"
+    else
+      x="ssl:${db_host}:${port}"
+    fi
+  elif [[ -z "${OVN_DB_IPS}" ]]; then
+    if [[ "${port}" == "${KUBE_OVN_NB_PORT}" ]]; then
       if [[ "$ENABLE_SSL" == "false" ]]; then
         x="tcp:[${OVN_NB_SERVICE_HOST}]:${OVN_NB_SERVICE_PORT}"
       else
@@ -27,9 +42,9 @@ function gen_conn_str {
   else
     t=$(echo -n "${OVN_DB_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-      x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "tcp:[$i]:${port}",; done | sed 's/,$//')
     else
-      x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "ssl:[$i]:${port}",; done | sed 's/,$//')
     fi
   fi
   echo "$x"

--- a/dist/images/start-db.sh
+++ b/dist/images/start-db.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -eo pipefail
 
+# DYNAMIC_PEERS short-circuit: hand off the entire lifecycle (preflight,
+# bring-up, runtime watchdog/kicker) to the ovn-central-controller binary,
+# which replaces both this script's dynamic-peers branch and the legacy
+# kube-ovn-leader-checker. The static (NODE_IPS-based) flow below is
+# unchanged.
+if [[ "${DYNAMIC_PEERS:-false}" == "true" ]]; then
+    exec /kube-ovn/ovn-central-controller
+fi
+
 DEBUG_WRAPPER=${DEBUG_WRAPPER:-}
 ENABLE_COMPACT=${ENABLE_COMPACT:-false}
 PROBE_INTERVAL=${PROBE_INTERVAL:-180000}

--- a/dist/images/start-ic-controller.sh
+++ b/dist/images/start-ic-controller.sh
@@ -6,10 +6,25 @@ OVN_NB_ADDR=${OVN_NB_ADDR:-}
 OVN_SB_ADDR=${OVN_SB_ADDR:-}
 KUBE_OVN_NB_PORT=${KUBE_OVN_NB_PORT:-6641}
 KUBE_OVN_SB_PORT=${KUBE_OVN_SB_PORT:-6642}
+OVN_NB_HOST=${OVN_NB_HOST:-}
+OVN_SB_HOST=${OVN_SB_HOST:-}
 
 function gen_conn_str {
-  if [[ -z "${OVN_DB_IPS}" ]]; then
-    if [[ "$1" == "$KUBE_OVN_NB_PORT" ]]; then
+  local port=$1
+  local db_host
+  if [[ "${port}" == "${KUBE_OVN_NB_PORT}" ]]; then
+    db_host="${OVN_NB_HOST}"
+  else
+    db_host="${OVN_SB_HOST}"
+  fi
+  if [[ -n "${db_host}" ]]; then
+    if [[ "$ENABLE_SSL" == "false" ]]; then
+      x="tcp:${db_host}:${port}"
+    else
+      x="ssl:${db_host}:${port}"
+    fi
+  elif [[ -z "${OVN_DB_IPS}" ]]; then
+    if [[ "${port}" == "${KUBE_OVN_NB_PORT}" ]]; then
       if [[ "$ENABLE_SSL" == "false" ]]; then
         x="tcp:[${OVN_NB_SERVICE_HOST}]:${OVN_NB_SERVICE_PORT}"
       else
@@ -25,9 +40,9 @@ function gen_conn_str {
   else
     t=$(echo -n "${OVN_DB_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     if [[ "$ENABLE_SSL" == "false" ]]; then
-      x=$(for i in ${t}; do echo -n "tcp:[$i]:$1",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "tcp:[$i]:${port}",; done | sed 's/,$//')
     else
-      x=$(for i in ${t}; do echo -n "ssl:[$i]:$1",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "ssl:[$i]:${port}",; done | sed 's/,$//')
     fi
   fi
   echo "$x"

--- a/dist/images/start-ovs.sh
+++ b/dist/images/start-ovs.sh
@@ -7,6 +7,7 @@ HW_OFFLOAD=${HW_OFFLOAD:-false}
 ENABLE_SSL=${ENABLE_SSL:-false}
 OVN_DB_IPS=${OVN_DB_IPS:-}
 OVN_SB_ADDR=${OVN_SB_ADDR:-}
+OVN_SB_HOST=${OVN_SB_HOST:-}
 TUNNEL_TYPE=${TUNNEL_TYPE:-geneve}
 FLOW_LIMIT=${FLOW_LIMIT:-10}
 DEBUG_WRAPPER=${DEBUG_WRAPPER:-}
@@ -123,7 +124,14 @@ handle_underlay_bridges
 /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
 
 function gen_conn_str {
-  if [[ -z "${OVN_DB_IPS}" ]]; then
+  local port=$1
+  if [[ -n "${OVN_SB_HOST}" ]]; then
+    if [[ "$ENABLE_SSL" == "false" ]]; then
+      x="tcp:${OVN_SB_HOST}:${port}"
+    else
+      x="ssl:${OVN_SB_HOST}:${port}"
+    fi
+  elif [[ -z "${OVN_DB_IPS}" ]]; then
     if [[ "$ENABLE_SSL" == "false" ]]; then
       x="tcp:[${OVN_SB_SERVICE_HOST}]:${OVN_SB_SERVICE_PORT}"
     else
@@ -133,9 +141,9 @@ function gen_conn_str {
     t=$(echo -n "${OVN_DB_IPS}" | sed 's/[[:space:]]//g' | sed 's/,/ /g')
     local port=${1:-${KUBE_OVN_SB_PORT:-6642}}
     if [[ "$ENABLE_SSL" == "false" ]]; then
-      x=$(for i in ${t}; do echo -n "tcp:[$i]:${port}",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "tcp:[$i]:${port}",; done | sed 's/,$//')
     else
-      x=$(for i in ${t}; do echo -n "ssl:[$i]:${port}",; done| sed 's/,$//')
+      x=$(for i in ${t}; do echo -n "ssl:[$i]:${port}",; done | sed 's/,$//')
     fi
   fi
   echo "$x"

--- a/dist/images/upgrade-ovs.sh
+++ b/dist/images/upgrade-ovs.sh
@@ -3,10 +3,11 @@
 set -ex
 
 POD_NAMESPACE=${POD_NAMESPACE:-kube-system}
+OVN_CENTRAL_KIND=${OVN_CENTRAL_KIND:-deployment}
 
 UPDATE_STRATEGY=`kubectl -n $POD_NAMESPACE get ds ovs-ovn -o jsonpath='{.spec.updateStrategy.type}'`
 
-kubectl -n $POD_NAMESPACE rollout status deploy ovn-central --timeout=120s
+kubectl -n $POD_NAMESPACE rollout status $OVN_CENTRAL_KIND ovn-central --timeout=120s
 
 if [ $UPDATE_STRATEGY = OnDelete ]; then
   dsChartVer=`kubectl get ds -n $POD_NAMESPACE ovs-ovn -o jsonpath={.spec.template.metadata.annotations.chart-version}`

--- a/pkg/ovn_central_controller/controller.go
+++ b/pkg/ovn_central_controller/controller.go
@@ -1,0 +1,972 @@
+// controller.go: orchestration of ovn-central startup + runtime loop.
+//
+// Lifecycle:
+//
+//	Run() -> parseConfig -> [preflight -> bringUp -> runtimeLoop] (retry on errRetry)
+//	  preflight:   sweep reconvert temp files, wipe kicked/stale-stub DBs.
+//	  bringUp:     start ovsdb-server, wait for cluster_member+leader. On
+//	               failure, take the bootstrap lease and recoverCluster()
+//	               picks wipe-rejoin / reconvert / bootstrap based on peer
+//	               state.
+//	  runtimeLoop: every TickInterval, watch leader health, label leaders,
+//	               kick stale members, backup raft headers, publish status.
+//	               If no-leader past NoLeaderTimeout, escalate to
+//	               recoverCluster().
+package ovn_central_controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// errRetry signals "this attempt failed transiently; re-enter preflight +
+// bringUp after backoff." Returned for cases like a peer holding the
+// bootstrap lease or peers not yet ready.
+var errRetry = errors.New("retry preflight/bringUp")
+
+// heartbeatFile name (under cfg.OVNRunDir) is touched by a dedicated
+// goroutine. The liveness probe checks file mtime to detect a hung Go
+// runtime (deadlock, frozen goroutines) without conflating with
+// orchestration-state false negatives like a long reconvert.
+const (
+	heartbeatFile   = "ovn-central-controller.alive"
+	heartbeatPeriod = 5 * time.Second
+)
+
+// lifecycleState tracks in-container facts that can't be derived from
+// disk alone:
+//   - dbInherited: did the on-disk DB exist at container start? Cleared
+//     by wipeDB and by initStub fresh-create. Differentiates statusStale
+//     (data carried over) from statusJoining (fresh stub).
+//   - wasActive / activeSince: did we observe statusActive consecutively
+//     for sustainedActiveTicks? wasActive is sticky once true so a brief
+//     leader-unknown blip leaves us at leader_lost, not stale.
+//   - hasCommittedData: latched once we observed cluster_member + known
+//     leader + (role=leader OR logHigh>logLow) in BOTH NB and SB,
+//     i.e. we have replicated state even if wasActive hasn't latched
+//     yet. Distinguishes statusJoined (just-joined stub with full data)
+//     from statusJoining (empty stub). Sticky once true.
+type lifecycleState struct {
+	dbInherited      bool
+	wasActive        bool
+	hasCommittedData bool
+	activeSince      time.Time
+
+	// lastHealthyOvsdbNanos / inRecovery are read by the heartbeat goroutine
+	// concurrently with the main goroutine that writes them. atomic.
+	//   - lastHealthyOvsdbNanos: unix-nanos of the last time
+	//     updateAndComputeStatus returned statusActive. Zero == never seen
+	//     active (heartbeat treats startup time as the baseline).
+	//   - inRecovery: true while a recoverCluster call is in flight. The
+	//     heartbeat goroutine uses a larger staleness threshold during
+	//     recovery (BootstrapLeaseDuration) to avoid killing the pod
+	//     during legitimate multi-minute reconvert.
+	lastHealthyOvsdbNanos atomic.Int64
+	inRecovery            atomic.Bool
+}
+
+// sustainedActiveTicks: brief 5-10s "active" glimpses (ovsdb-server
+// reporting cluster_member while AddServer is mid-flight against a
+// quorum-less leader) shouldn't latch wasActive=true; otherwise a
+// stub-only pod could later claim leader_lost and hijack a reconvert.
+const sustainedActiveTicks = 3
+
+// updateAndComputeStatus derives our current status from on-disk state,
+// ovsdb runtime state, and lifecycle flags. Has side effects on ls:
+// advances activeSince and latches wasActive once we've been sustained-
+// active. Called from preflight, bringUp, runtimeTick, and recoverCluster.
+func updateAndComputeStatus(ctx context.Context, cfg *Config, ls *lifecycleState) status {
+	if !readDBState(ctx, nbDB(cfg)).exists && !readDBState(ctx, sbDB(cfg)).exists {
+		return ""
+	}
+	nbCS, errNB := readClusterStatus(ctx, nbDB(cfg))
+	sbCS, errSB := readClusterStatus(ctx, sbDB(cfg))
+	// Latch hasCommittedData on the first tick where BOTH DBs report
+	// "committed-active" state. This is what isCommittedActive checks:
+	// cluster_member + known leader + (role=leader OR logHigh>logLow).
+	// Crucial because wasActive needs sustainedActiveTicks (~15s) to
+	// latch, but a fresh-joined follower has full replicated data
+	// long before that. Without this flag a peer racing to recover
+	// might classify us as "no data" and bootstrap fresh on top of us.
+	if !ls.hasCommittedData &&
+		errNB == nil && errSB == nil &&
+		isCommittedActive(nbCS) && isCommittedActive(sbCS) {
+		ls.hasCommittedData = true
+	}
+	if errNB == nil && errSB == nil && isCommittedActive(nbCS) && isCommittedActive(sbCS) {
+		if ls.activeSince.IsZero() {
+			ls.activeSince = time.Now()
+		}
+		if !ls.wasActive &&
+			time.Since(ls.activeSince) >= time.Duration(sustainedActiveTicks)*cfg.TickInterval {
+			ls.wasActive = true
+		}
+		ls.lastHealthyOvsdbNanos.Store(time.Now().UnixNano())
+		return statusActive
+	}
+	ls.activeSince = time.Time{}
+	switch {
+	case ls.wasActive:
+		return statusLeaderLost
+	case ls.hasCommittedData:
+		return statusJoined
+	case ls.dbInherited:
+		return statusStale
+	default:
+		return statusJoining
+	}
+}
+
+// isCommittedActive: ovsdb reports cluster_member + known leader, AND
+// (we're the leader OR our raft log has entries beyond the initial
+// stub). The log check filters out the optimistic "cluster_member"
+// status that ovsdb-server reports while AddServer is still mid-flight
+// against a quorum-less leader -- without it, a stub-only pod could
+// briefly look healthy and trick peers into a wipe-rejoin.
+func isCommittedActive(cs clusterStatus) bool {
+	if cs.status != "cluster member" || !isKnownLeader(cs.leader) {
+		return false
+	}
+	return cs.role == "leader" || cs.logHigh > cs.logLow
+}
+
+// Config carries env-var-driven knobs. Fields default-init to zero value;
+// parseConfig fills them.
+type Config struct {
+	PodName, PodNamespace, PodIP, NodeName string
+	DBClusterAddr                          string   // raft listen addr (= PodIP)
+	DBAddr                                 string   // single db addr passed to --db-{nb,sb}-addr
+	DBAddresses                            []string // listen addrs for db client port (dual-stack capable)
+	EnableSSL                              bool
+	NBPort, SBPort                         int
+	NBClusterPort, SBClusterPort           int
+	OVNNorthdNThreads                      int
+	OVNNorthdProbeInterval                 int    // ms
+	ProbeInterval                          int    // ms (NB/SB inactivity_probe)
+	OVNDir                                 string // /etc/ovn
+	OVNRunDir                              string // /var/run/ovn
+	EnableCompact                          bool   // periodic ovsdb-server/compact on leader
+	VersionCompatibility                   string // NB_Global options:version_compatibility
+	DebugWrapper                           string // --ovn-northd-wrapper / --ovsdb-{nb,sb}-wrapper, e.g. valgrind
+	TickInterval                           time.Duration
+	StaggerTimeout                         time.Duration // wait for cluster member+leader
+	NoLeaderTimeout                        time.Duration // watchdog threshold
+	DeadMemberTimeout                      time.Duration // kicker threshold
+	BackupInterval                         time.Duration
+	CompactInterval                        time.Duration
+	StaleStubTimeout                       time.Duration // preflight wipes notJoined stubs older than this
+	SelfReadyTimeout                       time.Duration // deadline for our own Pod.Ready post-recovery
+	OvsdbCrashTimeout                      time.Duration // socket-missing tolerance (fast fail in runtimeTick)
+	OvsdbStuckTimeout                      time.Duration // "no statusActive" tolerance outside recovery; doubles as the BootstrapLeaseDuration bound when inside recovery (heartbeat-based, catches hangs inside recoverCluster)
+	BootstrapLeaseDuration                 time.Duration // raft lease tenancy under recoverCluster
+	BootstrapRenewDeadline                 time.Duration // raft lease renewal deadline
+	ReconvertTimeout                       time.Duration // exec timeout for cluster-to-standalone
+}
+
+// SSLOptions returns the -p/-c/-C arg list for ovn-nbctl / ovn-sbctl /
+// ovsdb-client invocations when SSL is enabled, empty otherwise.
+func (c *Config) SSLOptions() []string {
+	if !c.EnableSSL {
+		return nil
+	}
+	return []string{
+		"-p", "/var/run/tls/key",
+		"-c", "/var/run/tls/cert",
+		"-C", "/var/run/tls/cacert",
+	}
+}
+
+func parseConfig() (*Config, error) {
+	c := &Config{
+		PodName:                getenv("POD_NAME", ""),
+		PodNamespace:           getenv("POD_NAMESPACE", "kube-system"),
+		PodIP:                  getenv("POD_IP", ""),
+		NodeName:               getenv("NODE_NAME", ""),
+		EnableSSL:              getenv("ENABLE_SSL", "false") == "true",
+		NBPort:                 atoiDefault(getenv("NB_PORT", ""), 6641),
+		SBPort:                 atoiDefault(getenv("SB_PORT", ""), 6642),
+		NBClusterPort:          atoiDefault(getenv("NB_CLUSTER_PORT", ""), 6643),
+		SBClusterPort:          atoiDefault(getenv("SB_CLUSTER_PORT", ""), 6644),
+		OVNNorthdNThreads:      atoiDefault(getenv("OVN_NORTHD_N_THREADS", ""), 1),
+		OVNNorthdProbeInterval: atoiDefault(getenv("OVN_NORTHD_PROBE_INTERVAL", ""), 5000),
+		ProbeInterval:          atoiDefault(getenv("PROBE_INTERVAL", ""), 180000),
+		OVNDir:                 getenv("OVN_DIR", "/etc/ovn"),
+		OVNRunDir:              getenv("OVN_RUN_DIR", "/var/run/ovn"),
+		EnableCompact:          getenv("ENABLE_COMPACT", "false") == "true",
+		VersionCompatibility:   getenv("OVN_VERSION_COMPATIBILITY", ""),
+		DebugWrapper:           getenv("DEBUG_WRAPPER", ""),
+		TickInterval:           5 * time.Second,
+		NoLeaderTimeout:        time.Duration(atoiDefault(getenv("NO_LEADER_TIMEOUT", ""), 30)) * time.Second,
+		DeadMemberTimeout:      time.Duration(atoiDefault(getenv("DEAD_MEMBER_TIMEOUT", ""), 120)) * time.Second,
+		BackupInterval:         time.Duration(atoiDefault(getenv("BACKUP_INTERVAL", ""), 60)) * time.Second,
+		CompactInterval:        time.Duration(atoiDefault(getenv("COMPACT_INTERVAL", ""), 300)) * time.Second,
+		StaleStubTimeout:       time.Duration(atoiDefault(getenv("STALE_STUB_TIMEOUT", ""), 120)) * time.Second,
+		SelfReadyTimeout:       30 * time.Second,
+		OvsdbCrashTimeout:      time.Duration(atoiDefault(getenv("OVSDB_CRASH_TIMEOUT", ""), 30)) * time.Second,
+		OvsdbStuckTimeout:      time.Duration(atoiDefault(getenv("OVSDB_STUCK_TIMEOUT", ""), 180)) * time.Second,
+		BootstrapLeaseDuration: time.Duration(atoiDefault(getenv("BOOTSTRAP_LEASE_DURATION", ""), 600)) * time.Second,
+		BootstrapRenewDeadline: time.Duration(atoiDefault(getenv("BOOTSTRAP_RENEW_DEADLINE", ""), 300)) * time.Second,
+		ReconvertTimeout:       time.Duration(atoiDefault(getenv("RECONVERT_TIMEOUT", ""), 300)) * time.Second,
+	}
+	if c.PodName == "" || c.PodIP == "" || c.NodeName == "" {
+		return nil, errors.New("POD_NAME, POD_IP and NODE_NAME env vars are required")
+	}
+	for _, p := range []struct {
+		name string
+		val  int
+	}{
+		{"NB_PORT", c.NBPort},
+		{"SB_PORT", c.SBPort},
+		{"NB_CLUSTER_PORT", c.NBClusterPort},
+		{"SB_CLUSTER_PORT", c.SBClusterPort},
+	} {
+		if p.val < 1 || p.val > 65535 {
+			return nil, fmt.Errorf("%s=%d out of range (1..65535)", p.name, p.val)
+		}
+	}
+	c.DBClusterAddr = c.PodIP
+
+	// ENABLE_BIND_LOCAL_IP=true makes ovsdb-server bind only this pod's
+	// addresses (instead of ::). For dual-stack POD_IPS may be multiple
+	// comma-separated values; --db-{nb,sb}-addr takes one (we use the
+	// primary PodIP), Local_Config/listen takes them all.
+	if getenv("ENABLE_BIND_LOCAL_IP", "false") == "true" {
+		c.DBAddr = c.PodIP
+		c.DBAddresses = splitCSV(getenv("POD_IPS", c.PodIP))
+		if len(c.DBAddresses) == 0 {
+			c.DBAddresses = []string{c.PodIP}
+		}
+	} else {
+		c.DBAddr = "::"
+		c.DBAddresses = []string{"::"}
+	}
+	c.StaggerTimeout = time.Duration(atoiDefault(getenv("DYNAMIC_JOIN_TIMEOUT", ""), 30)) * time.Second
+	return c, nil
+}
+
+// Run is the binary entry point. Returns nil on graceful shutdown
+// (SIGTERM/SIGINT), error on fatal failure; otherwise blocks forever in
+// the runtime loop. Retries preflight + bringUp after exponential backoff
+// when bringUp signals errRetry (someone else is bootstrapping, peers not
+// ready yet).
+func Run() error {
+	cfg, err := parseConfig()
+	if err != nil {
+		return err
+	}
+	kc, err := newKubeClient()
+	if err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	ls := &lifecycleState{}
+	// Seed lastHealthyOvsdbNanos with startup time so the heartbeat
+	// goroutine has a non-zero baseline. If we never reach statusActive,
+	// staleness measured from startup eventually crosses the threshold.
+	ls.lastHealthyOvsdbNanos.Store(time.Now().UnixNano())
+
+	startHeartbeat(ctx, cfg, ls)
+	// Snapshot whether DB files were present at container startup. The
+	// dbInherited flag is cleared by wipeDB and by initStub on fresh
+	// create, so it stays true only while the on-disk DB carries over
+	// from a prior container's life.
+	ls.dbInherited = readDBState(ctx, nbDB(cfg)).exists || readDBState(ctx, sbDB(cfg)).exists
+
+	// Publish initial status so peers see a fresh, accurate label
+	// even if we crash before reaching runtimeLoop. Empty cid is fine
+	// at this point; refreshStatus re-reads disk every call.
+	if err := refreshStatus(ctx, cfg, kc, updateAndComputeStatus(ctx, cfg, ls)); err != nil {
+		klog.Warningf("initial label publish: %v", err)
+	}
+
+	const (
+		baseDelay = 5 * time.Second
+		maxDelay  = 60 * time.Second
+	)
+	delay := baseDelay
+	for attempt := 1; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			klog.Infof("shutdown requested before attempt %d: %v", attempt, err)
+			return nil
+		}
+		if err := preflight(ctx, cfg, kc, ls); err != nil {
+			return fmt.Errorf("preflight (attempt %d): %w", attempt, err)
+		}
+		err := bringUp(ctx, cfg, kc, ls)
+		if err == nil {
+			err = runtimeLoop(ctx, cfg, kc, ls)
+			if err == nil || errors.Is(err, context.Canceled) {
+				return nil // graceful shutdown
+			}
+		}
+		if !errors.Is(err, errRetry) {
+			return fmt.Errorf("attempt %d: %w", attempt, err)
+		}
+		klog.Infof("attempt %d: %v; sleeping %s before retry", attempt, err, delay)
+		stopNBSBOvsdb()
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(delay):
+		}
+		if delay *= 2; delay > maxDelay {
+			delay = maxDelay
+		}
+	}
+}
+
+// preflight inspects each DB and wipes ones we can't recover from in-place.
+// Also sweeps leftover temp files from a crashed reconvert. Then publishes
+// our (post-wipe) state into pod labels.
+func preflight(ctx context.Context, cfg *Config, kc kubernetes.Interface, ls *lifecycleState) error {
+	for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+		// Sweep reconvert temp files. Atomic-rename design means the
+		// real db file is always either the pre-reconvert original or
+		// the post-reconvert new one -- never missing -- so these
+		// leftovers are always safe to drop.
+		_ = os.Remove(d.dbFile + ".sa-tmp")
+		_ = os.Remove(d.dbFile + ".new")
+
+		st := readDBState(ctx, d)
+		switch {
+		case !st.exists:
+			// nothing to validate
+		case st.kicked:
+			klog.Warningf("%s: kicked from cluster, wiping (%s)", d.short, d.dbFile)
+			if err := wipeDB(d); err != nil {
+				return err
+			}
+			ls.dbInherited = false
+			ls.hasCommittedData = false
+		case st.notJoined && dbAge(d) >= cfg.StaleStubTimeout:
+			klog.Warningf("%s: stale join-stub (>%s old), wiping", d.short, cfg.StaleStubTimeout)
+			if err := wipeDB(d); err != nil {
+				return err
+			}
+			ls.dbInherited = false
+			ls.hasCommittedData = false
+		}
+	}
+	return refreshStatus(ctx, cfg, kc, updateAndComputeStatus(ctx, cfg, ls))
+}
+
+// bringUp tries to make this pod a healthy cluster member. Strategy:
+//
+//  1. Compose the peer list from kubectl (master-labeled IPs minus self).
+//  2. For each DB without a file on disk, create a stub: rejoin-cluster
+//     (preserve SID, no AddServer needed) if hdr exists, else join-cluster,
+//     or create-cluster when no remotes (single-master deployment).
+//  3. Recreate Local_Config DB so ovsdb-server listens on the right ports.
+//  4. Start ovsdb-server; wait staggerTimeout for both DBs to reach
+//     `Status: cluster member` with a known leader.
+//  5. On success: start northd, refresh labels, return.
+//  6. On failure: take the bootstrap lease and either reconvert (we are
+//     the sole survivor with committed data) or create-cluster fresh (no
+//     peer has data). If we shouldn't be the one to act, exit and let
+//     kubelet retry.
+func bringUp(ctx context.Context, cfg *Config, kc kubernetes.Interface, ls *lifecycleState) error {
+	peers, err := pickPeerIPs(ctx, kc, cfg.PodNamespace, cfg.PodIP)
+	if err != nil {
+		return fmt.Errorf("pickPeerIPs: %w", err)
+	}
+	klog.Infof("peer IPs from kubectl: %v", peers)
+
+	bootstrap := false
+	for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+		// Local_Config carries listen addrs (db client port). For
+		// ENABLE_BIND_LOCAL_IP=true with multiple POD_IPS we listen on
+		// each (dual-stack); otherwise just on ::.
+		listenAddrs := make([]string, 0, len(cfg.DBAddresses))
+		for _, a := range cfg.DBAddresses {
+			listenAddrs = append(listenAddrs, listenAddr(a, d.port, cfg.EnableSSL))
+		}
+		if err := writeLocalConfigDB(d, listenAddrs); err != nil {
+			return fmt.Errorf("writeLocalConfigDB %s: %w", d.short, err)
+		}
+		if _, errStat := os.Stat(d.dbFile); errStat == nil {
+			continue
+		}
+		remoteAddrs := make([]string, 0, len(peers))
+		for _, p := range peers {
+			remoteAddrs = append(remoteAddrs, connAddr(p, d.clusterPort, cfg.EnableSSL))
+		}
+		boot, err := initStub(d, connAddr(cfg.DBClusterAddr, d.clusterPort, cfg.EnableSSL), remoteAddrs)
+		if err != nil {
+			return fmt.Errorf("initStub %s: %w", d.short, err)
+		}
+		// Fresh stub created in this container -- not "inherited" data,
+		// and no committed entries until raft replicates them in.
+		ls.dbInherited = false
+		ls.hasCommittedData = false
+		if boot {
+			bootstrap = true
+		}
+	}
+
+	if err := startNBSBOvsdb(cfg, peers); err != nil {
+		return err
+	}
+	postOvsdbStart(ctx, cfg)
+	if err := refreshStatus(ctx, cfg, kc, updateAndComputeStatus(ctx, cfg, ls)); err != nil {
+		klog.Warningf("label refresh after init: %v", err)
+	}
+
+	if err := waitForLeader(ctx, cfg, cfg.StaggerTimeout); err == nil {
+		klog.Infof("cluster ready, starting northd (bootstrap=%v)", bootstrap)
+		if err := refreshStatus(ctx, cfg, kc, updateAndComputeStatus(ctx, cfg, ls)); err != nil {
+			klog.Warningf("label refresh post-ready: %v", err)
+		}
+		return startNorthd(cfg, bootstrap, peers)
+	}
+
+	klog.Warningf("waitForLeader timed out, entering recovery decision")
+	stopNBSBOvsdb()
+	return recoverCluster(ctx, cfg, kc, ls, peers)
+}
+
+// recoverCluster acquires the bootstrap lease, then routes through the
+// tier hierarchy in recoverUnderLease. The lease is held through the
+// entire destructive op + restart-ovsdb + waitForLeader, so the next
+// pod to take the lease only ever sees a stable, published cluster
+// state.
+func recoverCluster(ctx context.Context, cfg *Config, kc kubernetes.Interface, ls *lifecycleState, peers []string) error {
+	klog.Infof("acquiring bootstrap lease for recovery decision")
+	// Flag the heartbeat watchdog so it switches to the larger
+	// BootstrapLeaseDuration staleness threshold. Deferred Store(false)
+	// ensures the flag clears even if recoverUnderLease panics.
+	ls.inRecovery.Store(true)
+	defer ls.inRecovery.Store(false)
+	return withBootstrapLease(ctx, kc, cfg,
+		func(c context.Context) error { return recoverUnderLease(c, cfg, kc, ls, peers) })
+}
+
+// recoverUnderLease classifies self + peers and picks a path:
+//
+//	tier:  active+ready > leader_lost > stale > joined > joining > (no data)
+//
+// (1) peer active+ready                  → wipe + rejoin
+// (2) self leader_lost / stale / joined  → reconvert (we have committed data)
+// (3) peer leader_lost / stale / joined  → defer (they outrank us)
+// (4) nobody has data                    → bootstrap fresh
+//
+// statusJoined is the "just-finished-joining" intermediate: a follower
+// has received committed log entries but wasActive hasn't latched yet
+// (needs sustainedActiveTicks). Treating it as a data-holder avoids
+// new pods bootstrapping fresh on top of a peer that just synced
+// (the i06 data-loss bug).
+func recoverUnderLease(ctx context.Context, cfg *Config, kc kubernetes.Interface, ls *lifecycleState, peers []string) error {
+	allPods, err := listPeers(ctx, kc, cfg.PodNamespace)
+	if err != nil {
+		return err
+	}
+	others := otherPeers(allPods, cfg.PodIP)
+	mySt := updateAndComputeStatus(ctx, cfg, ls)
+
+	if anyPeerActiveAndReady(others) {
+		klog.Warningf("recover: peer active+ready; wiping local DB for fresh join")
+		for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+			if err := wipeDB(d); err != nil {
+				return fmt.Errorf("wipe %s: %w", d.short, err)
+			}
+		}
+		ls.dbInherited = false
+		ls.hasCommittedData = false
+		return errRetry
+	}
+	// Data-holder statuses (in our preferred recovery-priority order).
+	dataHolders := []status{statusLeaderLost, statusStale, statusJoined}
+	for _, s := range dataHolders {
+		if mySt == s {
+			klog.Infof("recover: self %s; reconverting", s)
+			return executeUnderLease(ctx, cfg, kc, ls, "reconvert", peers, reconvertFn(cfg))
+		}
+		if anyPeerStatus(others, s) {
+			klog.Infof("recover: peer %s; deferring", s)
+			return errRetry
+		}
+	}
+	klog.Infof("recover: no peer has cluster data; bootstrapping fresh (mySt=%q)", mySt)
+	return executeUnderLease(ctx, cfg, kc, ls, "bootstrap", peers, func(_ context.Context) error {
+		for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+			if err := wipeDB(d); err != nil {
+				return fmt.Errorf("wipe %s: %w", d.short, err)
+			}
+			if _, err := initStub(d,
+				connAddr(cfg.DBClusterAddr, d.clusterPort, cfg.EnableSSL), nil); err != nil {
+				return err
+			}
+		}
+		ls.dbInherited = false
+		ls.hasCommittedData = false
+		return nil
+	})
+}
+
+// reconvertFn runs cluster-to-standalone + create-cluster on both NB
+// and SB. Preserves data; cid is regenerated.
+func reconvertFn(cfg *Config) func(context.Context) error {
+	return func(_ context.Context) error {
+		for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+			if err := reconvert(d, connAddr(cfg.DBClusterAddr, d.clusterPort, cfg.EnableSSL), nil, cfg.ReconvertTimeout); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// executeUnderLease runs fn (the destructive op), restarts ovsdb, waits
+// for leader, starts northd, and blocks on our own Pod.Ready=true
+// before returning -- all while still holding the lease. Holding until
+// Pod.Ready closes a race window: without it, we'd publish status=active
+// and release the lease before the kubelet readiness probe fires, and
+// the next pod to acquire would see status=active but ready=false (so
+// anyPeerActiveAndReady=false) and proceed to its own bootstrap →
+// split-brain. ctx.Err() is checked once before serving so a lease
+// lost mid-op aborts before any peer-visible side effect.
+func executeUnderLease(ctx context.Context, cfg *Config, kc kubernetes.Interface, ls *lifecycleState,
+	op string, peers []string, fn func(context.Context) error,
+) error {
+	// Diagnostic: peers don't consult statusRecovering for decisions
+	// (only active+ready), but it's useful in `kubectl describe`.
+	if err := refreshStatus(ctx, cfg, kc, statusRecovering); err != nil {
+		klog.Warningf("label publish recovering: %v", err)
+	}
+	if err := fn(ctx); err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("lease lost after %s, aborting: %w", op, err)
+	}
+	if err := startNBSBOvsdb(cfg, peers); err != nil {
+		return err
+	}
+	postOvsdbStart(ctx, cfg)
+	if err := waitForLeader(ctx, cfg, cfg.StaggerTimeout); err != nil {
+		return fmt.Errorf("waitForLeader after %s: %w", op, err)
+	}
+	if err := refreshStatus(ctx, cfg, kc, updateAndComputeStatus(ctx, cfg, ls)); err != nil {
+		klog.Warningf("label refresh post-recovery: %v", err)
+	}
+	if err := startNorthd(cfg, op == "bootstrap", peers); err != nil {
+		return err
+	}
+	if err := waitForSelfReady(ctx, cfg, kc, cfg.SelfReadyTimeout); err != nil {
+		klog.Warningf("waitForSelfReady after %s: %v (releasing lease anyway)", op, err)
+	}
+	return nil
+}
+
+// waitForSelfReady blocks until our Pod's PodReady condition is True
+// (kubelet's readiness probe has confirmed our cluster is serving) or
+// the deadline expires. Used to delay lease release so peers consistently
+// observe our active+ready state before they try to recover themselves.
+func waitForSelfReady(ctx context.Context, cfg *Config, kc kubernetes.Interface, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		getCtx, cancel := context.WithTimeout(ctx, apiCallTimeout)
+		pod, err := kc.CoreV1().Pods(cfg.PodNamespace).Get(getCtx, cfg.PodName, metav1.GetOptions{})
+		cancel()
+		if err == nil {
+			for _, c := range pod.Status.Conditions {
+				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+					return nil
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("self Pod.Ready did not become true within %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// runtimeLoop ticks until ctx is cancelled or runtimeTick returns
+// errRetry (no-leader watchdog escalation). errRetry bubbles to Run()
+// which restarts the preflight+bringUp cycle; lifecycle flags persist
+// (wasActive stays true), so we keep statusLeaderLost through the
+// recovery rather than dropping back to stale.
+func runtimeLoop(ctx context.Context, cfg *Config, kc kubernetes.Interface, ls *lifecycleState) error {
+	state := newRuntimeState()
+	tk := time.NewTicker(cfg.TickInterval)
+	defer tk.Stop()
+	klog.Infof("entering runtime loop (tick=%s)", cfg.TickInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-tk.C:
+			if err := runtimeTick(ctx, cfg, kc, ls, state); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// runtimeState holds per-DB watchdog/kicker memory across ticks. Single-
+// goroutine access; no synchronization needed.
+type runtimeState struct {
+	noLeaderSince    map[string]time.Time // db -> first time we observed Leader=unknown
+	socketGoneSince  map[string]time.Time // db -> first time ovs-appctl socket was missing
+	unhealthySince   map[string]time.Time // <db>:<sid> -> first time observed unhealthy
+	lastBackup       time.Time
+	lastCompact      time.Time
+	lastStatus       status // last published lifecycle status, for change-detection
+	patchedClusterID string // last cluster ID successfully written to the node label
+}
+
+func newRuntimeState() *runtimeState {
+	return &runtimeState{
+		noLeaderSince:   map[string]time.Time{},
+		socketGoneSince: map[string]time.Time{},
+		unhealthySince:  map[string]time.Time{},
+	}
+}
+
+// isOvsdbSocketMissing reports whether err from cluster/status looks like
+// "ovsdb-server is not there" (socket gone or refusing connections) vs a
+// slow/garbled response. Only the former triggers the crash watchdog.
+func isOvsdbSocketMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "No such file or directory") ||
+		strings.Contains(s, "no such file or directory") ||
+		strings.Contains(s, "Connection refused") ||
+		strings.Contains(s, "connection refused")
+}
+
+func runtimeTick(ctx context.Context, cfg *Config, kc kubernetes.Interface, ls *lifecycleState, st *runtimeState) error {
+	nbLeader, sbLeader := false, false
+	noLeaderTimedOut := false
+	for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+		cs, err := readClusterStatus(ctx, d)
+		if err != nil {
+			// Reached runtimeTick only after bringUp + waitForLeader
+			// succeeded, so a missing socket here means ovsdb-server
+			// crashed mid-run. Tolerate transient errors for
+			// OvsdbCrashTimeout (apiserver hiccup, slow host), then
+			// fail fatal so kubelet restarts the pod -- a fresh
+			// container goes through preflight again, which is the
+			// right path for a crashed ovsdb (in-place restart can
+			// hit the same corrupt-DB crash).
+			if isOvsdbSocketMissing(err) {
+				if t, ok := st.socketGoneSince[d.short]; !ok {
+					st.socketGoneSince[d.short] = time.Now()
+					klog.Warningf("%s: ovsdb-server socket gone; tolerating up to %s before pod restart", d.short, cfg.OvsdbCrashTimeout)
+				} else if time.Since(t) >= cfg.OvsdbCrashTimeout {
+					return fmt.Errorf("ovsdb-server %s unreachable for %s, exiting for pod restart", d.short, time.Since(t).Round(time.Second))
+				}
+			}
+			klog.Warningf("cluster/status %s: %v", d.short, err)
+			continue
+		}
+		delete(st.socketGoneSince, d.short)
+		if d.short == "nb" && cs.clusterID != "" && cs.clusterID != st.patchedClusterID {
+			if err := patchNodeClusterID(ctx, kc, cfg.NodeName, cs.clusterID); err != nil {
+				klog.Warningf("patchNodeClusterID: %v", err)
+			} else {
+				st.patchedClusterID = cs.clusterID
+			}
+		}
+		// Watchdog: prolonged no-leader is the sole quorum-loss signal we
+		// can read locally (raft only elects/keeps a leader with majority).
+		if isKnownLeader(cs.leader) {
+			delete(st.noLeaderSince, d.short)
+		} else {
+			if t, ok := st.noLeaderSince[d.short]; !ok {
+				st.noLeaderSince[d.short] = time.Now()
+				klog.Warningf("%s reports no leader (will check %s for recovery)", d.short, cfg.NoLeaderTimeout)
+			} else if time.Since(t) >= cfg.NoLeaderTimeout {
+				noLeaderTimedOut = true
+			}
+		}
+		if cs.role == "leader" {
+			kickStaleMembers(ctx, d, cs, cfg.DeadMemberTimeout, st)
+			if d.short == "nb" {
+				nbLeader = true
+			} else {
+				sbLeader = true
+			}
+		}
+	}
+
+	// Pod labels signal which pod is the NB / SB / northd leader so the
+	// kube-ovn-controller's Service selectors route to the right one.
+	// The northd-leader label is keyed on LOCAL ovn-northd state because
+	// only the pod whose own northd holds the SB lock should be in the
+	// Service endpoint.
+	if err := patchLeaderLabels(ctx, kc, cfg.PodNamespace, cfg.PodName,
+		nbLeader, sbLeader, localNorthdActive(ctx)); err != nil {
+		klog.Warningf("patchLeaderLabels: %v", err)
+	}
+
+	// SB leader steals the ovn-northd lock only if NO pod anywhere has
+	// an active northd (nobody is in the Service endpoint set). The
+	// previous holder probably died without releasing, so blasting the
+	// lock lets a standby take over. We must NOT steal when an active
+	// northd already exists -- doing so just kicks it out and creates
+	// a churn loop.
+	if sbLeader && !anyNorthdActive(ctx, kc, cfg.PodNamespace) {
+		klog.Warningf("no active northd anywhere, stealing lock")
+		if err := stealLock(ctx, cfg); err != nil {
+			klog.Errorf("stealLock: %v", err)
+		}
+	}
+
+	if time.Since(st.lastBackup) >= cfg.BackupInterval {
+		for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+			if err := backupHeader(ctx, d); err != nil {
+				klog.Warningf("backupHeader %s: %v", d.short, err)
+			}
+		}
+		st.lastBackup = time.Now()
+	}
+	// Publish status only on transitions (e.g. active -> leader_lost).
+	// Hung pods are caught via Pod.Ready (readiness probe), not via
+	// stale labels.
+	cur := updateAndComputeStatus(ctx, cfg, ls)
+	if cur != st.lastStatus {
+		if err := refreshStatus(ctx, cfg, kc, cur); err != nil {
+			klog.Warningf("refreshStatus: %v", err)
+		}
+		st.lastStatus = cur
+	}
+	if cfg.EnableCompact && time.Since(st.lastCompact) >= cfg.CompactInterval {
+		// Run on whoever's the current leader of each DB; compact is a
+		// raft-replicated snapshot operation that other members follow.
+		if nbLeader {
+			if err := compactDB(ctx, nbDB(cfg)); err != nil {
+				klog.Warningf("compactDB nb: %v", err)
+			}
+		}
+		if sbLeader {
+			if err := compactDB(ctx, sbDB(cfg)); err != nil {
+				klog.Warningf("compactDB sb: %v", err)
+			}
+		}
+		st.lastCompact = time.Now()
+	}
+
+	// No-leader watchdog. recoverCluster() always under the lease
+	// decides what to do; we never short-circuit on "peer claims
+	// active" because that would let us sit forever with stale local
+	// membership the cluster has moved past.
+	if noLeaderTimedOut {
+		klog.Warningf("no leader past timeout; running recovery")
+		stopNBSBOvsdb()
+		peers, err := pickPeerIPs(ctx, kc, cfg.PodNamespace, cfg.PodIP)
+		if err != nil {
+			klog.Warningf("pickPeerIPs in no-leader path: %v", err)
+			return errRetry
+		}
+		if err := recoverCluster(ctx, cfg, kc, ls, peers); err != nil {
+			return err // errRetry → Run() retries; other errors fatal
+		}
+		// Reconvert/bootstrap succeeded: ovsdb is back, we're leader.
+		delete(st.noLeaderSince, "nb")
+		delete(st.noLeaderSince, "sb")
+	}
+	return nil
+}
+
+// kickStaleMembers walks the cluster/status server list. For peers other
+// than self that have been silent past dead-timeout, sends cluster/kick.
+// "No last_msg" is treated as needing a grace period (we may have just
+// restarted; give peers a chance to phone home before we kick them).
+func kickStaleMembers(ctx context.Context, d dbInfo, cs clusterStatus, dead time.Duration, st *runtimeState) {
+	now := time.Now()
+	seen := map[string]struct{}{}
+	for _, s := range cs.servers {
+		if s.self {
+			continue
+		}
+		key := d.short + ":" + s.sid
+		seen[s.sid] = struct{}{}
+		var unhealthy bool
+		var reason string
+		var kickNow bool
+		if s.lastMsgMillis < 0 {
+			unhealthy = true
+			reason = "no last_contact recorded"
+		} else if time.Duration(s.lastMsgMillis)*time.Millisecond > dead {
+			unhealthy = true
+			reason = fmt.Sprintf("last contact %ds ago", s.lastMsgMillis/1000)
+			kickNow = true
+		}
+		if !unhealthy {
+			delete(st.unhealthySince, key)
+			continue
+		}
+		if kickNow {
+			klog.Infof("kicking %s member %s: %s", d.short, s.sid, reason)
+			if err := kickMember(ctx, d, s.sid); err != nil {
+				klog.Errorf("kick %s/%s: %v", d.short, s.sid, err)
+				continue
+			}
+			delete(st.unhealthySince, key)
+			continue
+		}
+		// no last_msg path: track first-observed; kick after grace.
+		if t, ok := st.unhealthySince[key]; !ok {
+			st.unhealthySince[key] = now
+			klog.Warningf("%s member %s observed unhealthy: %s (will kick after %s)",
+				d.short, s.sid, reason, dead)
+		} else if now.Sub(t) >= dead {
+			klog.Infof("kicking %s member %s: %s, unhealthy for %.0fs",
+				d.short, s.sid, reason, now.Sub(t).Seconds())
+			if err := kickMember(ctx, d, s.sid); err != nil {
+				klog.Errorf("kick %s/%s: %v", d.short, s.sid, err)
+				continue
+			}
+			delete(st.unhealthySince, key)
+		}
+	}
+	// Prune state for members no longer in cluster (already gone).
+	for key := range st.unhealthySince {
+		if !strings.HasPrefix(key, d.short+":") {
+			continue
+		}
+		sid := key[len(d.short)+1:]
+		if _, ok := seen[sid]; !ok {
+			delete(st.unhealthySince, key)
+		}
+	}
+}
+
+// refreshStatus publishes our current lifecycle status. Idempotent.
+func refreshStatus(ctx context.Context, cfg *Config, kc kubernetes.Interface, st status) error {
+	return publishStatus(ctx, kc, cfg.PodNamespace, cfg.PodName, st)
+}
+
+// startHeartbeat spawns a goroutine that touches cfg.OVNRunDir/heartbeatFile
+// every heartbeatPeriod. The liveness probe checks file mtime: stale ==
+// either the Go runtime is hung (deadlock, OOM-spin) OR ovsdb has been
+// unhealthy too long. Running independently of the main goroutine means
+// even a hang inside recoverCluster (where runtimeTick is suspended)
+// gets caught.
+//
+// Two staleness thresholds based on ls.inRecovery:
+//   - outside recovery: cfg.OvsdbStuckTimeout (default 3 min) -- ovsdb
+//     should be active in steady state; longer means we're stuck.
+//   - inside recovery: cfg.BootstrapLeaseDuration (default 10 min) --
+//     legitimate reconvert can take minutes on multi-GB DBs, so we
+//     tolerate the full lease window before declaring recovery stuck.
+//
+// When the threshold is crossed, the goroutine STOPS writing the file;
+// the external liveness probe then sees a stale mtime and kubelet kills
+// the pod for a fresh restart (which goes through preflight again).
+func startHeartbeat(ctx context.Context, cfg *Config, ls *lifecycleState) {
+	path := filepath.Join(cfg.OVNRunDir, heartbeatFile)
+	go func() {
+		if err := touchFile(path); err != nil {
+			klog.Warningf("initial heartbeat write %s: %v", path, err)
+		}
+		tk := time.NewTicker(heartbeatPeriod)
+		defer tk.Stop()
+		var lastWarn time.Time
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tk.C:
+				threshold := cfg.OvsdbStuckTimeout
+				inRec := ls.inRecovery.Load()
+				if inRec {
+					threshold = cfg.BootstrapLeaseDuration
+				}
+				stale := time.Since(time.Unix(0, ls.lastHealthyOvsdbNanos.Load()))
+				if stale > threshold {
+					// Rate-limit warnings to ~30s so we don't spam logs.
+					if time.Since(lastWarn) >= 30*time.Second {
+						klog.Warningf("heartbeat halted: ovsdb stale %s > %s (inRecovery=%v); liveness probe will trigger pod restart",
+							stale.Round(time.Second), threshold, inRec)
+						lastWarn = time.Now()
+					}
+					continue
+				}
+				if err := touchFile(path); err != nil {
+					klog.Warningf("heartbeat write %s: %v", path, err)
+				}
+			}
+		}
+	}()
+}
+
+// touchFile updates path's mtime to now, creating the file if absent.
+func touchFile(path string) error {
+	now := time.Now()
+	if err := os.Chtimes(path, now, now); err == nil {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+// pickPeerIPs returns peer Pod IPs for raft join/rejoin remotes. Pods
+// without an IP or Terminating are excluded; not-yet-Ready ones stay
+// because ovsdb-server retries until one responds.
+func pickPeerIPs(ctx context.Context, kc kubernetes.Interface, ns, selfIP string) ([]string, error) {
+	all, err := listPeers(ctx, kc, ns)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(all))
+	for _, p := range all {
+		if p.ip == "" || p.ip == selfIP || p.terminating {
+			continue
+		}
+		out = append(out, p.ip)
+	}
+	return out, nil
+}
+
+// trivial helpers
+
+func getenv(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func atoiDefault(s string, d int) int {
+	if v, err := strconv.Atoi(s); err == nil {
+		return v
+	}
+	return d
+}
+
+func splitCSV(s string) []string {
+	out := []string{}
+	for p := range strings.SplitSeq(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/pkg/ovn_central_controller/kube.go
+++ b/pkg/ovn_central_controller/kube.go
@@ -1,0 +1,310 @@
+// kube.go: kubernetes API helpers -- pod listing, labels, lease.
+// No DB knowledge here.
+package ovn_central_controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"strconv"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+// apiCallTimeout caps a single kube-apiserver request so a stuck apiserver
+// can't freeze a tick. Wrap List/Get/Patch with context.WithTimeout(ctx, ...).
+const apiCallTimeout = 10 * time.Second
+
+// retryDecisional retries fn on transient apiserver errors with
+// exponential backoff (~0.5s/1s/2s, total ≤3.5s). Use ONLY for reads
+// whose result drives a recovery decision (listPeers in bringUp /
+// recoverUnderLease). For diagnostic ops (publishStatus, patchLeaderLabels)
+// rely on next-tick natural retry instead.
+func retryDecisional(ctx context.Context, fn func() error) error {
+	backoff := wait.Backoff{
+		Steps:    3,
+		Duration: 500 * time.Millisecond,
+		Factor:   2.0,
+		Jitter:   0.1,
+	}
+	return retry.OnError(backoff, isTransientAPIError, func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return fn()
+	})
+}
+
+// isTransientAPIError returns true for apiserver errors worth retrying:
+// 5xx, throttling, network timeouts. NotFound/Forbidden/Unauthorized are
+// considered terminal (no point retrying).
+func isTransientAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) || apierrors.IsInternalError(err) {
+		return true
+	}
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		return true
+	}
+	return false
+}
+
+const (
+	labelStatus        = "kube-ovn.io/ovn-status"
+	labelNodeClusterID = "kube-ovn.io/ovn-nb-cluster-id"
+	bootstrapLeaseName = "ovn-central-bootstrap"
+	podLabelSelector   = "app=ovn-central"
+)
+
+// Lifecycle status published per pod. Recomputed every tick from disk +
+// ovsdb runtime state -- not sticky across container restarts. Only
+// statusActive (combined with Pod.Ready=true via the readiness probe)
+// is consulted by peers to trigger wipe-and-rejoin; the rest are
+// informational. statusRecovering is diagnostic-only.
+type status string
+
+const (
+	statusJoining    status = "joining"     // stub created here, no committed data observed yet
+	statusJoined     status = "joined"      // stub has received committed data via raft, but sustainedActive not yet latched
+	statusStale      status = "stale"       // DB existed at startup, not yet active in this container
+	statusLeaderLost status = "leader_lost" // was active in this container, no leader now
+	statusActive     status = "active"      // cluster_member + known leader + committed entries
+	statusRecovering status = "recovering"  // under bootstrap lease, mid destructive op
+)
+
+func newKubeClient() (kubernetes.Interface, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("in-cluster config: %w", err)
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+// peerInfo summarizes the kubectl-visible state of one ovn-central pod.
+//
+//   - ready: Pod.Status.Conditions[PodReady] -- the readiness probe runs
+//     `cluster_member + known leader + committed entries`, so a true
+//     value means this peer's label is trustworthy.
+//   - terminating: pod has DeletionTimestamp; about to vanish, may be
+//     hung in grace. Excluded from recovery decisions.
+type peerInfo struct {
+	ip          string
+	status      status
+	running     bool
+	ready       bool
+	terminating bool
+}
+
+func listPeers(ctx context.Context, kc kubernetes.Interface, ns string) ([]peerInfo, error) {
+	var pl *corev1.PodList
+	err := retryDecisional(ctx, func() error {
+		c, cancel := context.WithTimeout(ctx, apiCallTimeout)
+		defer cancel()
+		var lerr error
+		pl, lerr = kc.CoreV1().Pods(ns).List(c, metav1.ListOptions{LabelSelector: podLabelSelector})
+		return lerr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+	out := make([]peerInfo, 0, len(pl.Items))
+	for _, p := range pl.Items {
+		pi := peerInfo{
+			ip:          p.Status.PodIP,
+			running:     p.Status.Phase == corev1.PodRunning,
+			status:      status(p.Labels[labelStatus]),
+			terminating: p.DeletionTimestamp != nil,
+		}
+		for _, c := range p.Status.Conditions {
+			if c.Type == corev1.PodReady {
+				pi.ready = c.Status == corev1.ConditionTrue
+				break
+			}
+		}
+		out = append(out, pi)
+	}
+	return out, nil
+}
+
+// otherPeers returns peers we trust for recovery decisions: not self,
+// has a Pod IP, currently Running, not Terminating.
+func otherPeers(all []peerInfo, selfIP string) []peerInfo {
+	out := make([]peerInfo, 0, len(all))
+	for _, p := range all {
+		if p.ip == "" || p.ip == selfIP || !p.running || p.terminating {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// anyPeerStatus reports whether any peer matches one of the given statuses.
+func anyPeerStatus(peers []peerInfo, want ...status) bool {
+	for _, p := range peers {
+		if slices.Contains(want, p.status) {
+			return true
+		}
+	}
+	return false
+}
+
+// anyPeerActiveAndReady is the trustworthy "there's a healthy cluster"
+// signal: status=active AND kubelet's readiness probe passing. Stale
+// labels from hung or just-degraded pods would have ready=false.
+func anyPeerActiveAndReady(peers []peerInfo) bool {
+	for _, p := range peers {
+		if p.ready && p.status == statusActive {
+			return true
+		}
+	}
+	return false
+}
+
+// anyNorthdActive reports whether any pod is the active ovn-northd
+// (a Ready endpoint of the ovn-northd Service). API error fails safe
+// (returns true) so we don't stealLock and bump out a working northd.
+func anyNorthdActive(ctx context.Context, kc kubernetes.Interface, ns string) bool {
+	c, cancel := context.WithTimeout(ctx, apiCallTimeout)
+	defer cancel()
+	esl, err := kc.DiscoveryV1().EndpointSlices(ns).List(c, metav1.ListOptions{
+		LabelSelector: "kubernetes.io/service-name=ovn-northd",
+	})
+	if err != nil {
+		klog.Warningf("list ovn-northd endpointslices: %v", err)
+		return true
+	}
+	for _, es := range esl.Items {
+		for _, ep := range es.Endpoints {
+			if len(ep.Addresses) == 0 {
+				continue
+			}
+			if ep.Conditions.Ready == nil || *ep.Conditions.Ready {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// publishStatus patches our pod's lifecycle status label. Empty
+// status is sent as null so kubectl removes the label.
+func publishStatus(ctx context.Context, kc kubernetes.Interface, ns, name string, st status) error {
+	var val any
+	if st != "" {
+		val = string(st)
+	}
+	body, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{labelStatus: val},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	c, cancel := context.WithTimeout(ctx, apiCallTimeout)
+	defer cancel()
+	_, err = kc.CoreV1().Pods(ns).Patch(c, name, types.MergePatchType, body, metav1.PatchOptions{})
+	return err
+}
+
+// withBootstrapLease runs fn while holding the cluster-wide bootstrap
+// lease. Only one pod may be inside fn at a time -- this is the
+// invariant that keeps concurrent reconvert/create-cluster from forming
+// split-brain. Lease durations come from cfg: must comfortably exceed
+// the worst-case destructive op (reconvert on a multi-GB DB can take
+// minutes) so an apiserver hiccup doesn't release the lease mid-op.
+func withBootstrapLease(ctx context.Context, kc kubernetes.Interface, cfg *Config,
+	fn func(context.Context) error,
+) error {
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta:  metav1.ObjectMeta{Name: bootstrapLeaseName, Namespace: cfg.PodNamespace},
+		Client:     kc.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{Identity: cfg.PodName},
+	}
+	leCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		mu    sync.Mutex
+		fnErr error
+	)
+	leaderelection.RunOrDie(leCtx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   cfg.BootstrapLeaseDuration,
+		RenewDeadline:   cfg.BootstrapRenewDeadline,
+		RetryPeriod:     5 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(c context.Context) {
+				klog.Infof("acquired bootstrap lease, running action")
+				err := fn(c)
+				mu.Lock()
+				fnErr = err
+				mu.Unlock()
+				cancel()
+			},
+			OnStoppedLeading: func() { klog.Infof("released bootstrap lease") },
+		},
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	return fnErr
+}
+
+// patchNodeClusterID stamps the NB raft cluster UUID on the node so the
+// cluster membership history survives pod restarts. Only written; never cleared.
+func patchNodeClusterID(ctx context.Context, kc kubernetes.Interface, nodeName, clusterID string) error {
+	body, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{labelNodeClusterID: clusterID},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	c, cancel := context.WithTimeout(ctx, apiCallTimeout)
+	defer cancel()
+	_, err = kc.CoreV1().Nodes().Patch(c, nodeName, types.MergePatchType, body, metav1.PatchOptions{})
+	return err
+}
+
+// patchLeaderLabels stamps ovn-nb-leader / ovn-sb-leader / ovn-northd-leader
+// on this pod so the kube-ovn Service selectors route to the actual leaders.
+func patchLeaderLabels(ctx context.Context, kc kubernetes.Interface, ns, name string, nb, sb, northd bool) error {
+	body, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				"ovn-nb-leader":     strconv.FormatBool(nb),
+				"ovn-sb-leader":     strconv.FormatBool(sb),
+				"ovn-northd-leader": strconv.FormatBool(northd),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	c, cancel := context.WithTimeout(ctx, apiCallTimeout)
+	defer cancel()
+	_, err = kc.CoreV1().Pods(ns).Patch(c, name, types.MergePatchType, body, metav1.PatchOptions{})
+	return err
+}

--- a/pkg/ovn_central_controller/ovsdb.go
+++ b/pkg/ovn_central_controller/ovsdb.go
@@ -1,0 +1,571 @@
+// ovsdb.go: thin wrappers around ovsdb-tool / ovs-appctl / ovn-ctl.
+// All on-disk and runtime DB inspection lives here. No k8s, no orchestration.
+package ovn_central_controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Per-class exec timeouts. Callers pick a class by:
+//   - ctx = parent ctx (SIGTERM-killable) for health / corrective ops
+//   - ctx = context.Background() (detached) for mutational / ovn-ctl ops
+//     where SIGTERM mid-flight risks partial on-disk state
+//   - timeout constant matched to op cost:
+//     health=5s (read-only probes), corrective=10s (kick/compact/steal),
+//     mutational=60s (initStub, writeLocalConfigDB, set NB/SB Global),
+//     ovn-ctl=60s (start_*/stop_* — ovn-ctl has its own socket-wait),
+//     cfg.ReconvertTimeout for cluster-to-standalone on multi-GB DBs.
+const (
+	execTimeoutHealth     = 5 * time.Second
+	execTimeoutCorrective = 10 * time.Second
+	execTimeoutMutational = 60 * time.Second
+	execTimeoutOvnCtl     = 60 * time.Second
+)
+
+// dbInfo describes one of the two raft databases (NB or SB) we manage in lockstep.
+type dbInfo struct {
+	short        string // "nb" / "sb"
+	name         string // OVN_Northbound / OVN_Southbound
+	schema       string // ovs schema file
+	dbFile       string // /etc/ovn/ovnnb_db.db
+	hdrFile      string // /etc/ovn/ovnnb_db.hdr
+	localCfgFile string // /etc/ovn/ovnnb_local_config.db
+	ctlSocket    string // /var/run/ovn/ovnnb_db.ctl
+	port         int    // db client port (6641 / 6642)
+	clusterPort  int    // raft cluster port (6643 / 6644)
+}
+
+func nbDB(cfg *Config) dbInfo {
+	return dbInfo{
+		short:        "nb",
+		name:         "OVN_Northbound",
+		schema:       "/usr/share/ovn/ovn-nb.ovsschema",
+		dbFile:       filepath.Join(cfg.OVNDir, "ovnnb_db.db"),
+		hdrFile:      filepath.Join(cfg.OVNDir, "ovnnb_db.hdr"),
+		localCfgFile: filepath.Join(cfg.OVNDir, "ovnnb_local_config.db"),
+		ctlSocket:    filepath.Join(cfg.OVNRunDir, "ovnnb_db.ctl"),
+		port:         cfg.NBPort,
+		clusterPort:  cfg.NBClusterPort,
+	}
+}
+
+func sbDB(cfg *Config) dbInfo {
+	return dbInfo{
+		short:        "sb",
+		name:         "OVN_Southbound",
+		schema:       "/usr/share/ovn/ovn-sb.ovsschema",
+		dbFile:       filepath.Join(cfg.OVNDir, "ovnsb_db.db"),
+		hdrFile:      filepath.Join(cfg.OVNDir, "ovnsb_db.hdr"),
+		localCfgFile: filepath.Join(cfg.OVNDir, "ovnsb_local_config.db"),
+		ctlSocket:    filepath.Join(cfg.OVNRunDir, "ovnsb_db.ctl"),
+		port:         cfg.SBPort,
+		clusterPort:  cfg.SBClusterPort,
+	}
+}
+
+// dbState is the on-disk classification of one db file.
+type dbState struct {
+	exists    bool
+	kicked    bool // check-cluster reports server left/not in list
+	notJoined bool // join-stub that hasn't synced
+}
+
+// readDBState inspects on-disk state non-destructively.
+func readDBState(ctx context.Context, d dbInfo) dbState {
+	s := dbState{}
+	if _, err := os.Stat(d.dbFile); err != nil {
+		return s
+	}
+	s.exists = true
+
+	// check-cluster on a healthy DB exits non-zero ONLY when it has
+	// something to report; ignore the error and inspect the message.
+	msg, _ := runOutput(ctx, execTimeoutHealth, "ovsdb-tool", "check-cluster", d.dbFile)
+	if msg != "" {
+		// "left the cluster" (we issued cluster/leave) or "not found in
+		// server list" (leader kicked us): same outcome -- ovsdb-server
+		// won't start, must wipe.
+		if reCheckClusterGone.MatchString(msg) {
+			s.kicked = true
+		} else if strings.Contains(msg, "has not joined the cluster") {
+			s.notJoined = true
+		}
+	}
+	return s
+}
+
+// dbAge returns the time since the db file was created, or 0 if missing.
+func dbAge(d dbInfo) time.Duration {
+	st, err := os.Stat(d.dbFile)
+	if err != nil {
+		return 0
+	}
+	return time.Since(st.ModTime())
+}
+
+// wipeDB removes db_file and hdr_file. Idempotent.
+func wipeDB(d dbInfo) error {
+	if err := os.Remove(d.dbFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s: %w", d.dbFile, err)
+	}
+	_ = os.Remove(d.hdrFile)
+	return nil
+}
+
+// initStub creates a fresh db file: create-cluster (if no remotes),
+// rejoin-cluster (if hdr present, preserves SID, no AddServer needed),
+// or plain join-cluster otherwise. Mutational: detached from parent ctx.
+func initStub(d dbInfo, localAddr string, remotes []string) (bootstrapped bool, err error) {
+	if len(remotes) == 0 {
+		err = run(context.Background(), execTimeoutMutational, "ovsdb-tool", "create-cluster", d.dbFile, d.schema, localAddr)
+		return true, err
+	}
+	args := []string{}
+	if _, errStat := os.Stat(d.hdrFile); errStat == nil {
+		args = append(args, "rejoin-cluster", d.dbFile, d.hdrFile, localAddr)
+		args = append(args, remotes...)
+		if err := run(context.Background(), execTimeoutMutational, "ovsdb-tool", args...); err == nil {
+			return false, nil
+		}
+		// rejoin failed (corrupt header etc.) -- wipe and try plain join below.
+		_ = os.Remove(d.dbFile)
+		_ = os.Remove(d.hdrFile)
+	}
+	args = []string{"join-cluster", d.dbFile, d.name, localAddr}
+	args = append(args, remotes...)
+	return false, run(context.Background(), execTimeoutMutational, "ovsdb-tool", args...)
+}
+
+// reconvert recreates a 1-node cluster from our existing DB, atomically:
+// cluster-to-standalone -> create-cluster into .new -> rename onto
+// d.dbFile. At every crash point the original DB is still on disk
+// until the rename, so a half-finished reconvert never loses data.
+// Leftover .sa-tmp/.new are swept by preflight on startup.
+// Heavy mutational: detached from parent ctx; cluster-to-standalone uses
+// reconvertTimeout (can be minutes on multi-GB DBs).
+func reconvert(d dbInfo, localAddr string, remotes []string, reconvertTimeout time.Duration) error {
+	if !readDBState(context.Background(), d).exists {
+		return fmt.Errorf("reconvert: %s missing", d.dbFile)
+	}
+	sa := d.dbFile + ".sa-tmp"
+	newDB := d.dbFile + ".new"
+	cleanup := func() { _ = os.Remove(sa); _ = os.Remove(newDB) }
+	cleanup()
+	if err := run(context.Background(), reconvertTimeout, "ovsdb-tool", "cluster-to-standalone", sa, d.dbFile); err != nil {
+		cleanup()
+		return fmt.Errorf("cluster-to-standalone %s: %w", d.dbFile, err)
+	}
+	args := append([]string{"create-cluster", newDB, sa, localAddr}, remotes...)
+	if err := run(context.Background(), execTimeoutMutational, "ovsdb-tool", args...); err != nil {
+		cleanup()
+		return fmt.Errorf("create-cluster: %w", err)
+	}
+	if err := os.Rename(newDB, d.dbFile); err != nil {
+		cleanup()
+		return fmt.Errorf("rename %s -> %s: %w", newDB, d.dbFile, err)
+	}
+	_ = os.Remove(sa)
+	_ = os.Remove(d.hdrFile)
+	return nil
+}
+
+// startNBSBOvsdb starts both ovsdb-server processes via ovn-ctl. Returns
+// after ovn-ctl returns (which itself waits for the unix sockets to be
+// ready). Caller is responsible for waiting for the cluster to elect a
+// leader (see waitForLeader). Detached from parent ctx.
+func startNBSBOvsdb(cfg *Config, peers []string) error {
+	common := buildOvnCtlArgs(cfg, peers)
+	for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+		args := append([]string{}, common...)
+		args = append(args,
+			"start_"+d.short+"_ovsdb",
+			"--",
+			// db:Local_Config remote registers the db client port (6641/6642)
+			// listener. Mirrors what the legacy bash flow does.
+			"--remote=db:Local_Config,Config,connections",
+			d.localCfgFile,
+		)
+		if err := run(context.Background(), execTimeoutOvnCtl, "/usr/share/ovn/scripts/ovn-ctl", args...); err != nil {
+			return fmt.Errorf("start_%s_ovsdb failed: %w", d.short, err)
+		}
+	}
+	return nil
+}
+
+func stopNBSBOvsdb() {
+	for _, sub := range []string{"stop_nb_ovsdb", "stop_sb_ovsdb", "stop_northd"} {
+		_ = run(context.Background(), execTimeoutOvnCtl, "/usr/share/ovn/scripts/ovn-ctl", sub)
+	}
+}
+
+// startNorthd launches ovn-northd. Optionally writes NB_Global / SB_Global
+// option overrides if `bootstrap` (we just created a 1-node cluster).
+// Detached: ovn-ctl + ovn-{nb,sb}ctl are mutational on remote DB state.
+func startNorthd(cfg *Config, bootstrap bool, peers []string) error {
+	args := buildOvnCtlArgs(cfg, peers)
+	args = append(args,
+		"--ovn-manage-ovsdb=no",
+		fmt.Sprintf("--ovn-northd-n-threads=%d", cfg.OVNNorthdNThreads),
+		"start_northd",
+	)
+	if err := run(context.Background(), execTimeoutOvnCtl, "/usr/share/ovn/scripts/ovn-ctl", args...); err != nil {
+		return fmt.Errorf("start_northd: %w", err)
+	}
+	// Pass SSL options when ENABLE_SSL=true so ovn-{nb,sb}ctl can talk to the (TLS) DB.
+	ssl := cfg.SSLOptions()
+	mk := func(bin, table, kv string) []string {
+		a := append([]string{"--no-leader-only"}, ssl...)
+		a = append(a, "set", table, ".", kv)
+		return append([]string{bin}, a...)
+	}
+
+	// version_compatibility must be applied on every northd start so that rolling
+	// upgrades and pod restarts keep the NB schema version pinned correctly.
+	if cfg.VersionCompatibility != "" {
+		c := mk("ovn-nbctl", "NB_Global", "options:version_compatibility="+cfg.VersionCompatibility)
+		if err := run(context.Background(), execTimeoutMutational, c[0], c[1:]...); err != nil {
+			return fmt.Errorf("%v: %w", c, err)
+		}
+	}
+
+	if !bootstrap {
+		return nil
+	}
+	// On a fresh 1-node cluster, write NB/SB Global tunables. These are
+	// raft-replicated to followers when they later join.
+	probe := strconv.Itoa(cfg.ProbeInterval)
+	northdProbe := strconv.Itoa(cfg.OVNNorthdProbeInterval)
+	cmds := [][]string{
+		mk("ovn-nbctl", "NB_Global", "options:inactivity_probe="+probe),
+		mk("ovn-sbctl", "SB_Global", "options:inactivity_probe="+probe),
+		mk("ovn-nbctl", "NB_Global", "options:northd_probe_interval="+northdProbe),
+		mk("ovn-nbctl", "NB_Global", "options:use_logical_dp_groups=true"),
+	}
+	for _, c := range cmds {
+		if err := run(context.Background(), execTimeoutMutational, c[0], c[1:]...); err != nil {
+			return fmt.Errorf("%v: %w", c, err)
+		}
+	}
+	return nil
+}
+
+// postOvsdbStart enables memory-trim-on-compaction (lets the kernel
+// reclaim RSS after periodic compactions, prevents long-term bloat) and
+// locks down DB file permissions. Best-effort: failures are logged.
+func postOvsdbStart(ctx context.Context, cfg *Config) {
+	for _, d := range []dbInfo{nbDB(cfg), sbDB(cfg)} {
+		if err := run(ctx, execTimeoutCorrective, "ovn-appctl", "-t", d.ctlSocket, "ovsdb-server/memory-trim-on-compaction", "on"); err != nil {
+			klog.Warningf("memory-trim-on-compaction %s: %v", d.short, err)
+		}
+	}
+	matches, _ := filepath.Glob(filepath.Join(cfg.OVNDir, "*"))
+	for _, p := range matches {
+		_ = os.Chmod(p, 0o600)
+	}
+}
+
+// compactDB asks ovsdb-server to write a new snapshot now (truncates the
+// raft log to that snapshot). Cheap when there's little to compact, so we
+// can call it on every leader from the runtime loop with a long interval.
+func compactDB(ctx context.Context, d dbInfo) error {
+	return run(ctx, execTimeoutCorrective, "ovn-appctl", "-t", d.ctlSocket, "ovsdb-server/compact")
+}
+
+// localNorthdActive reports whether THIS pod's ovn-northd holds the SB
+// lock (i.e. is the writing northd). Drives the ovn-northd-leader label
+// on our pod, which the Service selector keys on.
+func localNorthdActive(ctx context.Context) bool {
+	out, err := runOutput(ctx, execTimeoutHealth, "ovn-appctl", "-t", "ovn-northd", "status")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.TrimSpace(out), "active")
+}
+
+// stealLock forces release of the ovn_northd lock on the local SB
+// database. Used when the previous lock holder went down without
+// releasing; without this, ovn-northd elsewhere can't take leadership.
+func stealLock(ctx context.Context, cfg *Config) error {
+	addr := connAddr(cfg.DBClusterAddr, cfg.SBPort, cfg.EnableSSL)
+	args := []string{"-v", "-t", "1"}
+	args = append(args, cfg.SSLOptions()...)
+	args = append(args, "steal", addr, "ovn_northd")
+	return run(ctx, execTimeoutCorrective, "ovsdb-client", args...)
+}
+
+// clusterStatus is the parsed view of `ovs-appctl ... cluster/status`.
+// Only the fields we read elsewhere are populated.
+type clusterStatus struct {
+	role      string // leader / follower / candidate / "" if unknown
+	leader    string // sid hex / "self" / "unknown" / ""
+	status    string // cluster member / joining cluster / left cluster
+	clusterID string // full UUID of the raft cluster, e.g. "b79ee8e0-e4c5-..."
+	logLow    int    // raft log range low index
+	logHigh   int    // raft log range high; logHigh==logLow means stub-only
+	servers   []serverInfo
+}
+
+type serverInfo struct {
+	sid           string
+	addr          string
+	self          bool
+	lastMsgMillis int64 // -1 if not present
+}
+
+var (
+	reLeaderLine       = regexp.MustCompile(`^Leader:\s+(\S+)`)
+	reRoleLine         = regexp.MustCompile(`^Role:\s+(\S+)`)
+	reStatusLine       = regexp.MustCompile(`^Status:\s+(.+)$`)
+	reClusterIDLine    = regexp.MustCompile(`^Cluster ID:\s+\S+\s+\(([0-9a-f-]+)\)`)
+	reSIDLine          = regexp.MustCompile(`^Server ID:\s+\S+\s+\(([0-9a-f-]+)\)`)
+	reLogLine          = regexp.MustCompile(`^Log:\s+\[(\d+),\s*(\d+)\]`)
+	reServerLine       = regexp.MustCompile(`^\s+([0-9a-f]+)\s+\([0-9a-f-]+\s+at\s+(\S+?)\)(.*)$`)
+	reLastMsg          = regexp.MustCompile(`last msg (\d+) ms ago`)
+	reCheckClusterGone = regexp.MustCompile(`shows that the server left the cluster|server [0-9a-f]+ not found in server list`)
+)
+
+// readClusterStatus calls ovs-appctl cluster/status. Returns an error
+// if the unix socket is unreachable (ovsdb-server down).
+func readClusterStatus(ctx context.Context, d dbInfo) (clusterStatus, error) {
+	// #nosec G204 -- d.ctlSocket and d.name are derived from our own dbInfo, not user input.
+	out, err := runOutput(ctx, execTimeoutHealth, "ovs-appctl", "-t", d.ctlSocket, "cluster/status", d.name)
+	if err != nil {
+		return clusterStatus{}, fmt.Errorf("cluster/status %s: %w (%s)", d.short, err, out)
+	}
+	cs := clusterStatus{}
+	var selfSID string
+	for line := range strings.SplitSeq(out, "\n") {
+		switch {
+		case reLeaderLine.MatchString(line):
+			cs.leader = reLeaderLine.FindStringSubmatch(line)[1]
+		case reRoleLine.MatchString(line):
+			cs.role = reRoleLine.FindStringSubmatch(line)[1]
+		case reStatusLine.MatchString(line):
+			cs.status = strings.TrimSpace(reStatusLine.FindStringSubmatch(line)[1])
+		case reClusterIDLine.MatchString(line):
+			cs.clusterID = reClusterIDLine.FindStringSubmatch(line)[1]
+		case reSIDLine.MatchString(line):
+			selfSID = reSIDLine.FindStringSubmatch(line)[1][:4]
+		case reLogLine.MatchString(line):
+			m := reLogLine.FindStringSubmatch(line)
+			lo, errLo := strconv.Atoi(m[1])
+			hi, errHi := strconv.Atoi(m[2])
+			if errLo != nil || errHi != nil {
+				klog.Warningf("readClusterStatus %s: cannot parse Log line %q (lo=%v hi=%v)", d.short, line, errLo, errHi)
+			}
+			cs.logLow, cs.logHigh = lo, hi
+		}
+		if m := reServerLine.FindStringSubmatch(line); m != nil {
+			si := serverInfo{sid: m[1], addr: m[2], lastMsgMillis: -1, self: m[1] == selfSID}
+			if lc := reLastMsg.FindStringSubmatch(m[3]); lc != nil {
+				ms, err := strconv.ParseInt(lc[1], 10, 64)
+				if err != nil {
+					klog.Warningf("readClusterStatus %s: cannot parse last msg %q: %v", d.short, lc[1], err)
+				} else {
+					si.lastMsgMillis = ms
+				}
+			}
+			cs.servers = append(cs.servers, si)
+		}
+	}
+	return cs, nil
+}
+
+// waitForLeader polls cluster/status until both DBs report Status: cluster
+// member and a known leader, or until timeout. Returns the elapsed time.
+func waitForLeader(ctx context.Context, cfg *Config, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		nb, errNB := readClusterStatus(ctx, nbDB(cfg))
+		sb, errSB := readClusterStatus(ctx, sbDB(cfg))
+		if errNB == nil && errSB == nil &&
+			nb.status == "cluster member" && sb.status == "cluster member" &&
+			isKnownLeader(nb.leader) && isKnownLeader(sb.leader) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out: nb=%q sb=%q", nb.leader, sb.leader)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func isKnownLeader(s string) bool { return s != "" && s != "unknown" }
+
+// kickMember asks the local (must be leader) ovsdb-server to remove peer.
+func kickMember(ctx context.Context, d dbInfo, peerSID string) error {
+	return run(ctx, execTimeoutCorrective, "ovs-appctl", "-t", d.ctlSocket, "cluster/kick", d.name, peerSID)
+}
+
+// backupHeader writes the local raft header JSON to hdr_file. Used by the
+// rejoin-cluster path to recreate a stub with the same SID after a DB loss.
+func backupHeader(ctx context.Context, d dbInfo) error {
+	c, cancel := context.WithTimeout(ctx, execTimeoutCorrective)
+	defer cancel()
+	// #nosec G204 -- d.dbFile is derived from our own dbInfo, not user input.
+	out, err := exec.CommandContext(c, "ovsdb-tool", "db-raft-header", d.dbFile).Output()
+	if err != nil {
+		return fmt.Errorf("db-raft-header %s: %w", d.dbFile, err)
+	}
+	tmp := d.hdrFile + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, d.hdrFile)
+}
+
+// writeLocalConfigDB recreates ovn{nb,sb}_local_config.db with the current
+// listen addresses for the db client port. ovn-ctl's
+// --remote=db:Local_Config,Config,connections reads this on every start.
+// Mutational: detached from parent ctx.
+func writeLocalConfigDB(d dbInfo, listenAddrs []string) error {
+	_ = os.Remove(d.localCfgFile)
+	if err := run(context.Background(), execTimeoutMutational, "ovsdb-tool", "create", d.localCfgFile, "/usr/share/openvswitch/local-config.ovsschema"); err != nil {
+		return err
+	}
+	// Initial empty Config row.
+	if err := run(context.Background(), execTimeoutMutational, "ovsdb-tool", "transact", d.localCfgFile, `[
+		"Local_Config",
+		{"op": "insert", "table": "Config", "row": {"connections": ["set", []]}}
+	]`); err != nil {
+		return err
+	}
+	for _, addr := range listenAddrs {
+		txn := fmt.Sprintf(`[
+			"Local_Config",
+			{"op": "insert", "table": "Connection", "uuid-name": "n", "row": {"target": %q}},
+			{"op": "mutate", "table": "Config", "where": [], "mutations": [["connections", "insert", ["set", [["named-uuid", "n"]]]]]}
+		]`, addr)
+		if err := run(context.Background(), execTimeoutMutational, "ovsdb-tool", "transact", d.localCfgFile, txn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildOvnCtlArgs constructs the common --db-{nb,sb}-... flags for ovn-ctl
+// invocations. Using just one peer in remote-addr is fine: ovsdb-server
+// learns the rest via the join-stub or already-committed cluster config.
+func buildOvnCtlArgs(cfg *Config, peers []string) []string {
+	args := []string{}
+	if cfg.DebugWrapper != "" {
+		args = append(args,
+			"--ovn-northd-wrapper="+cfg.DebugWrapper,
+			"--ovsdb-nb-wrapper="+cfg.DebugWrapper,
+			"--ovsdb-sb-wrapper="+cfg.DebugWrapper,
+		)
+	}
+	args = append(args,
+		"--db-cluster-schema-upgrade=no",
+		fmt.Sprintf("--db-nb-cluster-local-addr=[%s]", cfg.DBClusterAddr),
+		fmt.Sprintf("--db-sb-cluster-local-addr=[%s]", cfg.DBClusterAddr),
+		fmt.Sprintf("--db-nb-cluster-local-port=%d", cfg.NBClusterPort),
+		fmt.Sprintf("--db-sb-cluster-local-port=%d", cfg.SBClusterPort),
+		fmt.Sprintf("--db-nb-addr=[%s]", cfg.DBAddr),
+		fmt.Sprintf("--db-sb-addr=[%s]", cfg.DBAddr),
+		fmt.Sprintf("--db-nb-port=%d", cfg.NBPort),
+		fmt.Sprintf("--db-sb-port=%d", cfg.SBPort),
+		"--db-nb-use-remote-in-db=no",
+		"--db-sb-use-remote-in-db=no",
+	)
+	if cfg.EnableSSL {
+		args = append(args,
+			"--ovn-nb-db-ssl-key=/var/run/tls/key",
+			"--ovn-nb-db-ssl-cert=/var/run/tls/cert",
+			"--ovn-nb-db-ssl-ca-cert=/var/run/tls/cacert",
+			"--ovn-sb-db-ssl-key=/var/run/tls/key",
+			"--ovn-sb-db-ssl-cert=/var/run/tls/cert",
+			"--ovn-sb-db-ssl-ca-cert=/var/run/tls/cacert",
+			"--ovn-northd-ssl-key=/var/run/tls/key",
+			"--ovn-northd-ssl-cert=/var/run/tls/cert",
+			"--ovn-northd-ssl-ca-cert=/var/run/tls/cacert",
+			"--db-nb-cluster-local-proto=ssl",
+			"--db-sb-cluster-local-proto=ssl",
+			"--db-nb-cluster-remote-proto=ssl",
+			"--db-sb-cluster-remote-proto=ssl",
+		)
+	} else {
+		args = append(args,
+			"--db-nb-create-insecure-remote=yes",
+			"--db-sb-create-insecure-remote=yes",
+		)
+	}
+	if len(peers) > 0 {
+		args = append(args,
+			fmt.Sprintf("--db-nb-cluster-remote-addr=[%s]", peers[0]),
+			fmt.Sprintf("--db-sb-cluster-remote-addr=[%s]", peers[0]),
+			fmt.Sprintf("--db-nb-cluster-remote-port=%d", cfg.NBClusterPort),
+			fmt.Sprintf("--db-sb-cluster-remote-port=%d", cfg.SBClusterPort),
+		)
+	}
+	allPeers := append([]string{cfg.DBClusterAddr}, peers...)
+	nbConn := commaJoin("tcp:[%s]:"+strconv.Itoa(cfg.NBPort), allPeers, cfg.EnableSSL)
+	sbConn := commaJoin("tcp:[%s]:"+strconv.Itoa(cfg.SBPort), allPeers, cfg.EnableSSL)
+	args = append(args,
+		"--ovn-northd-nb-db="+nbConn,
+		"--ovn-northd-sb-db="+sbConn,
+	)
+	return args
+}
+
+func commaJoin(format string, peers []string, ssl bool) string {
+	if ssl {
+		format = strings.Replace(format, "tcp:", "ssl:", 1)
+	}
+	parts := make([]string, 0, len(peers))
+	for _, p := range peers {
+		parts = append(parts, fmt.Sprintf(format, p))
+	}
+	return strings.Join(parts, ",")
+}
+
+// listenAddr formats the --remote=p{tcp,ssl}: listener used by ovsdb-server.
+func listenAddr(addr string, port int, ssl bool) string {
+	proto := "ptcp"
+	if ssl {
+		proto = "pssl"
+	}
+	return fmt.Sprintf("%s:%d:[%s]", proto, port, addr)
+}
+
+// connAddr formats a raft remote (peer cluster-port) address.
+func connAddr(addr string, port int, ssl bool) string {
+	proto := "tcp"
+	if ssl {
+		proto = "ssl"
+	}
+	return fmt.Sprintf("%s:[%s]:%d", proto, addr, port)
+}
+
+// run executes cmd with a deadline derived from timeout, bound to ctx.
+// Output streams to our stderr.
+func run(ctx context.Context, timeout time.Duration, name string, args ...string) error {
+	c, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(c, name, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// runOutput is like run but returns combined stdout+stderr regardless of exit.
+func runOutput(ctx context.Context, timeout time.Duration, name string, args ...string) (string, error) {
+	c, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	out, err := exec.CommandContext(c, name, args...).CombinedOutput()
+	return string(out), err
+}

--- a/pkg/ovn_central_controller/ovsdb.go
+++ b/pkg/ovn_central_controller/ovsdb.go
@@ -470,7 +470,7 @@ func buildOvnCtlArgs(cfg *Config, peers []string) []string {
 		)
 	}
 	args = append(args,
-		"--db-cluster-schema-upgrade=no",
+		"--db-cluster-schema-upgrade=yes",
 		fmt.Sprintf("--db-nb-cluster-local-addr=[%s]", cfg.DBClusterAddr),
 		fmt.Sprintf("--db-sb-cluster-local-addr=[%s]", cfg.DBClusterAddr),
 		fmt.Sprintf("--db-nb-cluster-local-port=%d", cfg.NBClusterPort),


### PR DESCRIPTION
Summary

Introduces a new ovn-central-controller binary that owns the full OVN central DB lifecycle (preflight, bring-up, runtime watchdog) when DYNAMIC_PEERS=true. It replaces the dynamic-peers branch of start-db.sh and the legacy kube-ovn-leader-checker for that mode, and recovers in-process to avoid kubelet restart cycles.

What's included

    New package pkg/ovn_central_controller/ (controller + kube + ovsdb helpers) and cmd/ovn_central_controller entrypoint wired into cmd/cmdmain.go.
    Lifecycle: preflight → bringUp → runtimeLoop, with recoverCluster() choosing between wipe-rejoin / reconvert / bootstrap based on peer state. Periodic leader labeling, stale-member kicking, raft header backup, and status publishing.
    start-db.sh short-circuit: execs the new binary when DYNAMIC_PEERS=true; static NODE_IPS flow unchanged.
    New readiness probe ovn-central-controller-readiness.sh: passes only when both NB and SB report cluster member with a known leader and committed log range — prevents stub pods from being treated as authoritative during AddServer.
    Helm: new DYNAMIC_PEERS / DYNAMIC_JOIN_TIMEOUT values, RBAC additions, Dockerfile copies the probe script.

