### PR TITLE
[release-1.15] fix: use per-family match for dual-stack EIP/SNAT policies

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -81,7 +81,9 @@ type FakeControllerOptions struct {
 	Vlans              []*kubeovnv1.Vlan
 	NetworkAttachments []*nadv1.NetworkAttachmentDefinition
 	Pods               []*corev1.Pod
+	Nodes              []*corev1.Node
 	Namespaces         []*corev1.Namespace
+	ConfigMaps         []*corev1.ConfigMap
 }
 
 // newFakeControllerWithOptions creates a fake controller with optional pre-populated objects
@@ -105,13 +107,19 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		namespaces = []*corev1.Namespace{defaultNamespace}
 	}
 
-	// Create fake Kubernetes client with namespaces and pods
-	kubeObjects := make([]runtime.Object, 0, len(namespaces)+len(opts.Pods))
+	// Create fake Kubernetes client with namespaces, pods, nodes, and configmaps
+	kubeObjects := make([]runtime.Object, 0, len(namespaces)+len(opts.Pods)+len(opts.Nodes)+len(opts.ConfigMaps))
 	for _, ns := range namespaces {
 		kubeObjects = append(kubeObjects, ns)
 	}
 	for _, pod := range opts.Pods {
 		kubeObjects = append(kubeObjects, pod)
+	}
+	for _, node := range opts.Nodes {
+		kubeObjects = append(kubeObjects, node)
+	}
+	for _, cm := range opts.ConfigMaps {
+		kubeObjects = append(kubeObjects, cm)
 	}
 	kubeClient := fake.NewSimpleClientset(kubeObjects...)
 
@@ -155,6 +163,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
 	podInformer := kubeInformerFactory.Core().V1().Pods()
 	nodeInformer := kubeInformerFactory.Core().V1().Nodes()
+	configMapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 
 	nadInformerFactory := nadinformers.NewSharedInformerFactory(nadClient, 0)
 	nadInformer := nadInformerFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions()
@@ -189,6 +198,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		namespacesLister:        namespaceInformer.Lister(),
 		podsLister:              podInformer.Lister(),
 		nodesLister:             nodeInformer.Lister(),
+		configMapsLister:        configMapInformer.Lister(),
 		vpcsLister:              vpcInformer.Lister(),
 		vpcSynced:               alwaysReady,
 		subnetsLister:           subnetInformer.Lister(),

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -731,6 +731,35 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 	return pod, nil
 }
 
+type policyRouteMatch struct {
+	match     string
+	nextHopIP string
+}
+
+func policyRouteSrcMatches(podIP, nextHop string) []policyRouteMatch {
+	var matches []policyRouteMatch
+	nextHopV4, nextHopV6 := util.SplitStringIP(nextHop)
+	nextHopV4, _, _ = strings.Cut(nextHopV4, "/")
+	nextHopV6, _, _ = strings.Cut(nextHopV6, "/")
+	for podAddr := range strings.SplitSeq(podIP, ",") {
+		var hop string
+		switch util.CheckProtocol(podAddr) {
+		case kubeovnv1.ProtocolIPv4:
+			hop = nextHopV4
+		case kubeovnv1.ProtocolIPv6:
+			hop = nextHopV6
+		}
+		if hop == "" {
+			continue
+		}
+		matches = append(matches, policyRouteMatch{
+			match:     fmt.Sprintf("%s.src == %s", getIPSuffix(util.CheckProtocol(podAddr)), podAddr),
+			nextHopIP: hop,
+		})
+	}
+	return matches
+}
+
 // do the same thing as update pod
 func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kubeovnNet) error {
 	// the lb-svc pod has dependencies on Running state, check it when pod state get updated
@@ -855,25 +884,32 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 						return errors.New("no available gateway address")
 					}
 				}
-				if strings.Contains(nextHop, "/") {
-					nextHop = strings.Split(nextHop, "/")[0]
+				legacyMatch := "ip4.src == " + podIP
+				matches := policyRouteSrcMatches(podIP, nextHop)
+				if !slices.ContainsFunc(matches, func(m policyRouteMatch) bool { return m.match == legacyMatch }) {
+					if err := c.deletePolicyRouteFromVpc(subnet.Spec.Vpc, util.NorthGatewayRoutePolicyPriority, legacyMatch); err != nil {
+						klog.Errorf("failed to delete stale policy route, %v", err)
+						return err
+					}
 				}
 
-				if err := c.addPolicyRouteToVpc(
-					subnet.Spec.Vpc,
-					&kubeovnv1.PolicyRoute{
-						Priority:  util.NorthGatewayRoutePolicyPriority,
-						Match:     "ip4.src == " + podIP,
-						Action:    kubeovnv1.PolicyRouteActionReroute,
-						NextHopIP: nextHop,
-					},
-					map[string]string{
-						"vendor": util.CniTypeName,
-						"subnet": subnet.Name,
-					},
-				); err != nil {
-					klog.Errorf("failed to add policy route, %v", err)
-					return err
+				for _, match := range matches {
+					if err := c.addPolicyRouteToVpc(
+						subnet.Spec.Vpc,
+						&kubeovnv1.PolicyRoute{
+							Priority:  util.NorthGatewayRoutePolicyPriority,
+							Match:     match.match,
+							Action:    kubeovnv1.PolicyRouteActionReroute,
+							NextHopIP: match.nextHopIP,
+						},
+						map[string]string{
+							"vendor": util.CniTypeName,
+							"subnet": subnet.Name,
+						},
+					); err != nil {
+						klog.Errorf("failed to add policy route, %v", err)
+						return err
+					}
 				}
 
 				// remove lsp from port group to make EIP/SNAT work
@@ -917,22 +953,14 @@ func (c *Controller) reconcileRouteSubnets(pod *v1.Pod, needRoutePodNets []*kube
 				}
 
 				if pod.Annotations[util.NorthGatewayAnnotation] != "" && pod.Annotations[util.IPAddressAnnotation] != "" {
-					for podAddr := range strings.SplitSeq(pod.Annotations[util.IPAddressAnnotation], ",") {
-						if util.CheckProtocol(podAddr) != util.CheckProtocol(pod.Annotations[util.NorthGatewayAnnotation]) {
-							continue
-						}
-						ipSuffix := "ip4"
-						if util.CheckProtocol(podAddr) == kubeovnv1.ProtocolIPv6 {
-							ipSuffix = "ip6"
-						}
-
+					for _, match := range policyRouteSrcMatches(pod.Annotations[util.IPAddressAnnotation], pod.Annotations[util.NorthGatewayAnnotation]) {
 						if err := c.addPolicyRouteToVpc(
 							subnet.Spec.Vpc,
 							&kubeovnv1.PolicyRoute{
 								Priority:  util.NorthGatewayRoutePolicyPriority,
-								Match:     fmt.Sprintf("%s.src == %s", ipSuffix, podAddr),
+								Match:     match.match,
 								Action:    kubeovnv1.PolicyRouteActionReroute,
-								NextHopIP: pod.Annotations[util.NorthGatewayAnnotation],
+								NextHopIP: match.nextHopIP,
 							},
 							map[string]string{
 								"vendor": util.CniTypeName,

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -7,6 +7,7 @@ import (
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -15,6 +16,7 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ipam"
+	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -961,4 +963,227 @@ func TestGetPodAttachmentNetIPAMOnlyNADGone(t *testing.T) {
 	require.Len(t, nets, 1)
 	assert.Equal(t, "net1.default", nets[0].ProviderName)
 	assert.Equal(t, "ipam-net1", nets[0].Subnet.Name)
+}
+
+func TestReconcileRouteSubnetsEIPUsesPerFamilyPolicyMatch(t *testing.T) {
+	const (
+		nodeName   = "node1"
+		podIPv4    = "10.40.0.13"
+		podIPv6    = "2001:db8:1:801:1::d"
+		dualPodIP  = podIPv4 + "," + podIPv6
+		v4OnlyIP   = "10.42.0.6"
+		nextHop    = "203.0.113.62"
+		eipV4      = "203.0.113.26"
+		macAddress = "00:00:00:00:00:01"
+	)
+
+	tests := []struct {
+		name          string
+		podIP         string
+		nextHop       string
+		snat          bool
+		wantPolicies  []policyRouteMatch
+		wantLegacyDel string
+	}{
+		{
+			name:    "dual-stack pod with IPv4 external gateway",
+			podIP:   dualPodIP,
+			nextHop: nextHop + "/26",
+			wantPolicies: []policyRouteMatch{
+				{match: "ip4.src == " + podIPv4, nextHopIP: nextHop},
+			},
+			wantLegacyDel: "ip4.src == " + dualPodIP,
+		},
+		{
+			name:    "IPv4-only pod keeps a single ip4.src match",
+			podIP:   v4OnlyIP,
+			nextHop: nextHop,
+			wantPolicies: []policyRouteMatch{
+				{match: "ip4.src == " + v4OnlyIP, nextHopIP: nextHop},
+			},
+		},
+		{
+			name:    "dual-stack pod with IPv6 external gateway",
+			podIP:   dualPodIP,
+			nextHop: "2001:db8:2::1",
+			wantPolicies: []policyRouteMatch{
+				{match: "ip6.src == " + podIPv6, nextHopIP: "2001:db8:2::1"},
+			},
+			wantLegacyDel: "ip4.src == " + dualPodIP,
+		},
+		{
+			name:    "dual-stack pod with dual-stack external gateway",
+			podIP:   dualPodIP,
+			nextHop: nextHop + "/26,2001:db8:2::1/64",
+			wantPolicies: []policyRouteMatch{
+				{match: "ip4.src == " + podIPv4, nextHopIP: nextHop},
+				{match: "ip6.src == " + podIPv6, nextHopIP: "2001:db8:2::1"},
+			},
+			wantLegacyDel: "ip4.src == " + dualPodIP,
+		},
+		{
+			name:    "IPv4-only SNAT pod keeps a single ip4.src match",
+			podIP:   v4OnlyIP,
+			nextHop: nextHop,
+			snat:    true,
+			wantPolicies: []policyRouteMatch{
+				{match: "ip4.src == " + v4OnlyIP, nextHopIP: nextHop},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			annotations := map[string]string{
+				util.AllocatedAnnotation:     "true",
+				util.IPAddressAnnotation:     tc.podIP,
+				util.MacAddressAnnotation:    macAddress,
+				util.LogicalSwitchAnnotation: "ovn-default",
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "repro-dualstack",
+					Namespace:   metav1.NamespaceDefault,
+					UID:         "pod-uid",
+					Annotations: annotations,
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			}
+			subnet := &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "ovn-default"},
+				Spec: kubeovnv1.SubnetSpec{
+					CIDRBlock: "10.40.0.0/16,2001:db8:1:801:1::/80",
+					Gateway:   "10.40.0.1,2001:db8:1:801:1::1",
+					Protocol:  kubeovnv1.ProtocolDual,
+					Provider:  util.OvnProvider,
+					Vpc:       util.DefaultVpc,
+					Default:   true,
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						util.PortNameAnnotation: nodeName,
+					},
+				},
+			}
+			gwCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.ExternalGatewayConfig,
+					Namespace: metav1.NamespaceSystem,
+				},
+				Data: map[string]string{
+					"external-gw-addr": tc.nextHop,
+				},
+			}
+			fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				Pods:       []*corev1.Pod{pod},
+				Nodes:      []*corev1.Node{node},
+				Subnets:    []*kubeovnv1.Subnet{subnet},
+				ConfigMaps: []*corev1.ConfigMap{gwCM},
+			})
+			require.NoError(t, err)
+			fc.fakeController.config.EnableEipSnat = true
+			fc.fakeController.config.ExternalGatewayConfigNS = metav1.NamespaceSystem
+
+			portName := ovs.PodNameToPortName(pod.Name, pod.Namespace, util.OvnProvider)
+			fc.mockOvnClient.EXPECT().ListPortGroups(gomock.Any()).Return(nil, nil).AnyTimes()
+			fc.mockOvnClient.EXPECT().RemovePortFromPortGroups(portName).Return(nil)
+			fc.mockOvnClient.EXPECT().PortGroupAddPorts(gomock.Any(), portName).Return(nil)
+			fc.mockOvnClient.EXPECT().PortGroupRemovePorts(gomock.Any(), portName).Return(nil)
+			if tc.snat {
+				pod.Annotations[util.SnatAnnotation] = eipV4
+			} else {
+				pod.Annotations[util.EipAnnotation] = eipV4
+			}
+			fc.mockOvnClient.EXPECT().UpdateDnatAndSnat(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			fc.mockOvnClient.EXPECT().UpdateSnat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			fc.mockOvnClient.EXPECT().DeleteNats(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			if tc.wantLegacyDel != "" {
+				fc.mockOvnClient.EXPECT().DeleteLogicalRouterPolicy(util.DefaultVpc, util.NorthGatewayRoutePolicyPriority, tc.wantLegacyDel).Return(nil)
+			}
+			for _, policy := range tc.wantPolicies {
+				fc.mockOvnClient.EXPECT().AddLogicalRouterPolicy(
+					util.DefaultVpc,
+					util.NorthGatewayRoutePolicyPriority,
+					policy.match,
+					string(kubeovnv1.PolicyRouteActionReroute),
+					[]string{policy.nextHopIP},
+					([]string)(nil),
+					map[string]string{"vendor": util.CniTypeName, "subnet": subnet.Name},
+				).Return(nil)
+			}
+
+			err = fc.fakeController.reconcileRouteSubnets(pod, []*kubeovnNet{{
+				ProviderName: util.OvnProvider,
+				Subnet:       subnet,
+				IsDefault:    true,
+			}})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPolicyRouteSrcMatches(t *testing.T) {
+	tests := []struct {
+		name    string
+		podIP   string
+		nextHop string
+		want    []policyRouteMatch
+	}{
+		{
+			name:    "dual-stack pod with IPv4 next hop",
+			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
+			nextHop: "203.0.113.62",
+			want:    []policyRouteMatch{{match: "ip4.src == 10.40.0.13", nextHopIP: "203.0.113.62"}},
+		},
+		{
+			name:    "dual-stack pod with IPv6 next hop",
+			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
+			nextHop: "2001:db8:2::1",
+			want:    []policyRouteMatch{{match: "ip6.src == 2001:db8:1:801:1::d", nextHopIP: "2001:db8:2::1"}},
+		},
+		{
+			name:    "IPv4-only pod",
+			podIP:   "10.42.0.6",
+			nextHop: "203.0.113.62",
+			want:    []policyRouteMatch{{match: "ip4.src == 10.42.0.6", nextHopIP: "203.0.113.62"}},
+		},
+		{
+			name:    "IPv6-only pod",
+			podIP:   "2001:db8:1:801:1::d",
+			nextHop: "2001:db8:2::1",
+			want:    []policyRouteMatch{{match: "ip6.src == 2001:db8:1:801:1::d", nextHopIP: "2001:db8:2::1"}},
+		},
+		{
+			name:    "family mismatch yields no match",
+			podIP:   "2001:db8:1:801:1::d",
+			nextHop: "203.0.113.62",
+		},
+		{
+			name:    "dual-stack pod with dual-stack next hop",
+			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
+			nextHop: "203.0.113.62,2001:db8:2::1",
+			want: []policyRouteMatch{
+				{match: "ip4.src == 10.40.0.13", nextHopIP: "203.0.113.62"},
+				{match: "ip6.src == 2001:db8:1:801:1::d", nextHopIP: "2001:db8:2::1"},
+			},
+		},
+		{
+			name:    "dual-stack CIDR next hop strips prefixes per family",
+			podIP:   "10.40.0.13,2001:db8:1:801:1::d",
+			nextHop: "203.0.113.62/26,2001:db8:2::1/64",
+			want: []policyRouteMatch{
+				{match: "ip4.src == 10.40.0.13", nextHopIP: "203.0.113.62"},
+				{match: "ip6.src == 2001:db8:1:801:1::d", nextHopIP: "2001:db8:2::1"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, policyRouteSrcMatches(tc.podIP, tc.nextHop))
+		})
+	}
 }


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes

Backport of #7401 to `release-1.15`.

Dual-stack pods annotated with `ovn.kubernetes.io/eip` or `ovn.kubernetes.io/snat` were programmed with a single `ip4.src` match that concatenated both addresses, e.g. `ip4.src == 10.40.0.13,2001:db8:1:801:1::d`. OVN accepts that policy, but it never matches. Because this path also removes the LSP from the subnet port group to disable `natOutgoing`, the pod is left with no external connectivity.

This change builds one policy per address family, pairing each pod IP with the matching external-gateway next hop (`ip4.src` / `ip6.src`). Dual-stack CIDR next hops are split per family instead of being truncated at the first `/`. The historical concatenated match is deleted on reconcile so already-broken dual-stack pods recover after upgrade.

## Which issue(s) this PR fixes

Fixes #7400

Cherry-picked from 4fe5af48dcb862246fbd636baede65ad22918015.

`release-1.15` still uses `UpdateSnat` rather than `EnsureSnat`, so the SNAT unit test mocks `UpdateSnat`. Fake controller options gained `Nodes` and `ConfigMaps` so the EIP/SNAT reconcile test can load `ovn-external-gw-config`.

## Validation

- `go test ./pkg/controller -count=1 -timeout 180s -run 'TestPolicyRouteSrcMatches|TestReconcileRouteSubnetsEIPUsesPerFamilyPolicyMatch|TestFakeControllerWithOptions|Test_allSubnetReady'`