### PR TITLE
test(e2e): gate MetalLB VIP datapath assertions to v1.15+

### DIFF
--- a/test/e2e/metallb/e2e_test.go
+++ b/test/e2e/metallb/e2e_test.go
@@ -706,24 +706,27 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 
 		service = f.ServiceClient().Get(serviceName)
 		service2 = f.ServiceClient().Get(serviceName2)
-		tcpLoadBalancer := f.VpcClient().Get(util.DefaultVpc).Status.TCPLoadBalancer
-		framework.ExpectNotEmpty(tcpLoadBalancer, "default VPC TCP load balancer should be set")
+		var tcpLoadBalancer string
 		vipNodes := make(map[string]string, 2)
-		for _, svc := range []*corev1.Service{service, service2} {
-			for _, clusterIP := range svc.Spec.ClusterIPs {
-				if util.CheckProtocol(clusterIP) == apiv1.ProtocolIPv4 {
-					expectNoUnderlayVIPBypassLFlow(clusterIP, curlListenPort)
+		if !f.VersionPriorTo(1, 15) {
+			tcpLoadBalancer = f.VpcClient().Get(util.DefaultVpc).Status.TCPLoadBalancer
+			framework.ExpectNotEmpty(tcpLoadBalancer, "default VPC TCP load balancer should be set")
+			for _, svc := range []*corev1.Service{service, service2} {
+				for _, clusterIP := range svc.Spec.ClusterIPs {
+					if util.CheckProtocol(clusterIP) == apiv1.ProtocolIPv4 {
+						expectNoUnderlayVIPBypassLFlow(clusterIP, curlListenPort)
+					}
 				}
-			}
-			for _, ingress := range svc.Status.LoadBalancer.Ingress {
-				if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
-					continue
+				for _, ingress := range svc.Status.LoadBalancer.Ingress {
+					if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
+						continue
+					}
+					vipNode := getVIPNodeFromService(f, svc.Name)
+					vipNodes[ingress.IP] = vipNode
+					waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, util.NodeLspName(vipNode), 30*time.Second)
+					waitUnderlayVIPBypassLFlow(ingress.IP, curlListenPort, 30*time.Second)
+					waitUnderlayVIPNodeLFlow(ingress.IP, util.NodeLspName(vipNode), curlListenPort, 30*time.Second)
 				}
-				vipNode := getVIPNodeFromService(f, svc.Name)
-				vipNodes[ingress.IP] = vipNode
-				waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, util.NodeLspName(vipNode), 30*time.Second)
-				waitUnderlayVIPBypassLFlow(ingress.IP, curlListenPort, 30*time.Second)
-				waitUnderlayVIPNodeLFlow(ingress.IP, util.NodeLspName(vipNode), curlListenPort, 30*time.Second)
 			}
 		}
 
@@ -743,71 +746,73 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 			}
 		}
 
-		ginkgo.By("Switching the first service to externalTrafficPolicy=Cluster")
-		modifiedService := service.DeepCopy()
-		modifiedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
-		service = serviceClient.PatchSync(service, modifiedService, func(s *corev1.Service) (bool, error) {
-			return s.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeCluster, nil
-		}, "externalTrafficPolicy is Cluster")
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
-				continue
+		if !f.VersionPriorTo(1, 15) {
+			ginkgo.By("Switching the first service to externalTrafficPolicy=Cluster")
+			modifiedService := service.DeepCopy()
+			modifiedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+			service = serviceClient.PatchSync(service, modifiedService, func(s *corev1.Service) (bool, error) {
+				return s.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeCluster, nil
+			}, "externalTrafficPolicy is Cluster")
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
+					continue
+				}
+				waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, "", 30*time.Second)
+				waitUnderlayVIPBypassLFlowCleaned(ingress.IP, curlListenPort, 30*time.Second)
+				waitUnderlayVIPNodeLFlowCleaned(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
 			}
-			waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, "", 30*time.Second)
-			waitUnderlayVIPBypassLFlowCleaned(ingress.IP, curlListenPort, 30*time.Second)
-			waitUnderlayVIPNodeLFlowCleaned(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
-		}
-		ginkgo.By("Verifying backend L2 lookup lflows are cleaned up for externalTrafficPolicy=Cluster")
-		clusterBackendPods, err := cs.CoreV1().Pods(f.Namespace.Name).List(context.Background(), metav1.ListOptions{
-			LabelSelector: "app=nginx",
-		})
-		framework.ExpectNoError(err, "listing backends of the first service")
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
-				continue
+			ginkgo.By("Verifying backend L2 lookup lflows are cleaned up for externalTrafficPolicy=Cluster")
+			clusterBackendPods, err := cs.CoreV1().Pods(f.Namespace.Name).List(context.Background(), metav1.ListOptions{
+				LabelSelector: "app=nginx",
+			})
+			framework.ExpectNoError(err, "listing backends of the first service")
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
+					continue
+				}
+				waitUnderlayVIPBackendLFlowAbsent(clusterBackendPods.Items, vipNodes[ingress.IP], 30*time.Second)
 			}
-			waitUnderlayVIPBackendLFlowAbsent(clusterBackendPods.Items, vipNodes[ingress.IP], 30*time.Second)
-		}
-		waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
+			waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
 
-		ginkgo.By("Checking the first service remains reachable with externalTrafficPolicy=Cluster")
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
-				checkReachable(f, containerID, clientIPv4, clientIPv6, ingress.IP, "80", clusterName, true)
+			ginkgo.By("Checking the first service remains reachable with externalTrafficPolicy=Cluster")
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+					checkReachable(f, containerID, clientIPv4, clientIPv6, ingress.IP, "80", clusterName, true)
+				}
 			}
-		}
 
-		ginkgo.By("Refreshing endpoints while the first service uses externalTrafficPolicy=Cluster")
-		deployClient.SetScale(deployName, 2)
-		deployClient.RolloutStatus(deployName)
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
-				waitLoadBalancerVIPBackendCount(tcpLoadBalancer, ingress.IP, curlListenPort, 2, 30*time.Second)
+			ginkgo.By("Refreshing endpoints while the first service uses externalTrafficPolicy=Cluster")
+			deployClient.SetScale(deployName, 2)
+			deployClient.RolloutStatus(deployName)
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+					waitLoadBalancerVIPBackendCount(tcpLoadBalancer, ingress.IP, curlListenPort, 2, 30*time.Second)
+				}
 			}
-		}
-		deployClient.SetScale(deployName, 3)
-		deployClient.RolloutStatus(deployName)
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
-				waitLoadBalancerVIPBackendCount(tcpLoadBalancer, ingress.IP, curlListenPort, 3, 30*time.Second)
+			deployClient.SetScale(deployName, 3)
+			deployClient.RolloutStatus(deployName)
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+					waitLoadBalancerVIPBackendCount(tcpLoadBalancer, ingress.IP, curlListenPort, 3, 30*time.Second)
+				}
 			}
-		}
 
-		ginkgo.By("Switching the first service back to externalTrafficPolicy=Local")
-		modifiedService = service.DeepCopy()
-		modifiedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
-		service = serviceClient.PatchSync(service, modifiedService, func(s *corev1.Service) (bool, error) {
-			return s.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal, nil
-		}, "externalTrafficPolicy is Local")
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
-				continue
+			ginkgo.By("Switching the first service back to externalTrafficPolicy=Local")
+			modifiedService = service.DeepCopy()
+			modifiedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+			service = serviceClient.PatchSync(service, modifiedService, func(s *corev1.Service) (bool, error) {
+				return s.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal, nil
+			}, "externalTrafficPolicy is Local")
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				if util.CheckProtocol(ingress.IP) != apiv1.ProtocolIPv4 {
+					continue
+				}
+				waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), 30*time.Second)
+				waitUnderlayVIPBypassLFlow(ingress.IP, curlListenPort, 30*time.Second)
+				waitUnderlayVIPNodeLFlow(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
 			}
-			waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), 30*time.Second)
-			waitUnderlayVIPBypassLFlow(ingress.IP, curlListenPort, 30*time.Second)
-			waitUnderlayVIPNodeLFlow(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
+			waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
 		}
-		waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
 
 		ginkgo.By("Restarting ds kube-ovn-cni")
 		daemonSetClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
@@ -829,13 +834,15 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 		ginkgo.By("Waiting for first service's underlay OpenFlow rules to be cleaned up")
 		for _, ingress := range service.Status.LoadBalancer.Ingress {
 			waitUnderlayServiceFlowCleaned(nodeNames, providerNetworkName, ingress.IP, curlListenPort, 30*time.Second)
-			if util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+			if !f.VersionPriorTo(1, 15) && util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
 				waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, "", 30*time.Second)
 				waitUnderlayVIPBypassLFlowCleaned(ingress.IP, curlListenPort, 30*time.Second)
 				waitUnderlayVIPNodeLFlowCleaned(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
 			}
 		}
-		waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
+		if !f.VersionPriorTo(1, 15) {
+			waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
+		}
 
 		ginkgo.By("Checking the second service is still reachable after first service deletion")
 		for i, ingress := range service2.Status.LoadBalancer.Ingress {

--- a/test/e2e/metallb/e2e_test.go
+++ b/test/e2e/metallb/e2e_test.go
@@ -663,6 +663,7 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 
 	framework.ConformanceIt("should support MetalLB underlay service lifecycle", func() {
 		env := setupUnderlayEnvironment()
+		hasInternalUnderlayVIP := !f.VersionPriorTo(1, 15)
 
 		ginkgo.By("Create deploy in underlay subnet")
 		podLabels := map[string]string{"app": "nginx"}
@@ -708,7 +709,7 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 		service2 = f.ServiceClient().Get(serviceName2)
 		var tcpLoadBalancer string
 		vipNodes := make(map[string]string, 2)
-		if !f.VersionPriorTo(1, 15) {
+		if hasInternalUnderlayVIP {
 			tcpLoadBalancer = f.VpcClient().Get(util.DefaultVpc).Status.TCPLoadBalancer
 			framework.ExpectNotEmpty(tcpLoadBalancer, "default VPC TCP load balancer should be set")
 			for _, svc := range []*corev1.Service{service, service2} {
@@ -746,7 +747,7 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 			}
 		}
 
-		if !f.VersionPriorTo(1, 15) {
+		if hasInternalUnderlayVIP {
 			ginkgo.By("Switching the first service to externalTrafficPolicy=Cluster")
 			modifiedService := service.DeepCopy()
 			modifiedService.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
@@ -834,13 +835,13 @@ var _ = framework.SerialDescribe("[group:metallb]", func() {
 		ginkgo.By("Waiting for first service's underlay OpenFlow rules to be cleaned up")
 		for _, ingress := range service.Status.LoadBalancer.Ingress {
 			waitUnderlayServiceFlowCleaned(nodeNames, providerNetworkName, ingress.IP, curlListenPort, 30*time.Second)
-			if !f.VersionPriorTo(1, 15) && util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
+			if hasInternalUnderlayVIP && util.CheckProtocol(ingress.IP) == apiv1.ProtocolIPv4 {
 				waitLoadBalancerVIPNodeMarker(tcpLoadBalancer, ingress.IP, "", 30*time.Second)
 				waitUnderlayVIPBypassLFlowCleaned(ingress.IP, curlListenPort, 30*time.Second)
 				waitUnderlayVIPNodeLFlowCleaned(ingress.IP, util.NodeLspName(vipNodes[ingress.IP]), curlListenPort, 30*time.Second)
 			}
 		}
-		if !f.VersionPriorTo(1, 15) {
+		if hasInternalUnderlayVIP {
 			waitServiceVIPNodeMarkers(tcpLoadBalancer, service2, vipNodes, 30*time.Second)
 		}
 


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Tests

CI always checks out master e2e against release branch images. The MetalLB underlay service lifecycle case was extended in #7040 with `kube-ovn.io/local-external-vip` markers and VIP lflows that only exist in v1.15+. On `release-1.14` this made `OVN METALLB E2E` fail while waiting for that marker, for example https://github.com/kubeovn/kube-ovn/actions/runs/34209720994/job/102310010973.

Keep the original underlay combine coverage on v1.14 (OpenFlow install/restore, reachability, u2o) and run the 1.15-only VIP datapath / ETP Local assertions only when the tested version is not prior to 1.15. Internal VIP topology cases already skip via `SkipVersionPriorTo(1, 15)`.

## Which issue(s) this PR fixes

Fixes none