### PR TITLE
fix(controller): configure VMI migration ports while pending

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -335,6 +335,8 @@ type Controller struct {
 	addOrUpdateVMIMigrationQueue workqueue.TypedRateLimitingInterface[string]
 	deleteVMQueue                workqueue.TypedRateLimitingInterface[string]
 	kubevirtInformerFactory      informer.KubeVirtInformerFactory
+	// vmiMigrationIndexer tracks migrations by VMI so terminal cleanup can yield to a newer migration.
+	vmiMigrationIndexer cache.Indexer
 
 	netAttachLister          netAttachv1.NetworkAttachmentDefinitionLister
 	netAttachSynced          cache.InformerSynced
@@ -462,6 +464,8 @@ func Run(ctx context.Context, config *Configuration) {
 	kubevirtInformerFactory := informer.NewKubeVirtInformerFactoryWithOptions(config.KubevirtClient.RestClient(), config.KubevirtClient,
 		informer.WithTransform(util.TrimManagedFields),
 	)
+	// Keep the migration indexer used by the informer; it is updated before migration events reach the queue.
+	vmiMigrationIndexer := kubevirtInformerFactory.VirtualMachineInstanceMigration().GetIndexer()
 	// Dedicated factory so that on clusters without the ServiceCIDR API the
 	// failed list/watch does not contaminate the main informer factory.
 	serviceCIDRInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(config.KubeClient, 0,
@@ -703,6 +707,7 @@ func Run(ctx context.Context, config *Configuration) {
 		addOrUpdateVMIMigrationQueue: newTypedRateLimitingQueue[string]("AddOrUpdateVMIMigration", nil),
 		deleteVMQueue:                newTypedRateLimitingQueue[string]("DeleteVM", nil),
 		kubevirtInformerFactory:      kubevirtInformerFactory,
+		vmiMigrationIndexer:          vmiMigrationIndexer,
 
 		netAttachLister:          netAttachInformer.Lister(),
 		netAttachSynced:          netAttachInformer.Informer().HasSynced,

--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -144,6 +144,17 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 		// needed to roll back those options.
 		switch vmiMigration.Status.Phase {
 		case kubevirtv1.MigrationFailed:
+			// A stale Failed event can be processed after a newer migration has already
+			// pinned the same ports. Do not let the old event roll back the newer options.
+			hasUnfinishedMigration, err := c.hasUnfinishedVMIMigration(vmiMigration)
+			if err != nil {
+				return err
+			}
+			if hasUnfinishedMigration {
+				klog.Infof("VirtualMachineInstanceMigration %s is stale because another migration for VMI %s is unfinished, skipping cleanup",
+					key, vmiMigration.Spec.VMIName)
+				return nil
+			}
 			srcNodeName = vmi.Status.NodeName
 		case kubevirtv1.MigrationSucceeded:
 			klog.V(3).Infof("VirtualMachineInstanceMigration %s migration state is Succeeded but VMI migration state is stale or nil, skipping", key)
@@ -251,6 +262,32 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 		}
 	}
 	return nil
+}
+
+// hasUnfinishedVMIMigration reports whether another migration for the same VMI is still active.
+// Terminal cleanup must yield to any such migration because its OVN options may already own the ports.
+func (c *Controller) hasUnfinishedVMIMigration(vmiMigration *kubevirtv1.VirtualMachineInstanceMigration) (bool, error) {
+	if c.vmiMigrationIndexer == nil {
+		return false, nil
+	}
+
+	key := fmt.Sprintf("%s/%s", vmiMigration.Namespace, vmiMigration.Spec.VMIName)
+	migrations, err := c.vmiMigrationIndexer.ByIndex(informer.ByVMINameIndex, key)
+	if err != nil {
+		return false, fmt.Errorf("failed to find migrations for VMI %s: %w", key, err)
+	}
+
+	for _, obj := range migrations {
+		migration, ok := obj.(*kubevirtv1.VirtualMachineInstanceMigration)
+		if !ok {
+			return false, fmt.Errorf("unexpected object type %T in VMI migration index", obj)
+		}
+		if migration.UID != vmiMigration.UID && !migration.IsFinal() {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (c *Controller) isKubevirtCRDInstalled() (bool, error) {

--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -105,7 +105,11 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 		utilruntime.HandleError(fmt.Errorf("failed to get VMI migration by key %s: %w", key, err))
 		return err
 	}
-	if vmiMigration.Status.MigrationState == nil {
+	// MigrationState may still be nil before target virt-launcher pod handoff. Pending and
+	// Scheduling can derive both nodes without it, so allow network setup to proceed.
+	if vmiMigration.Status.MigrationState == nil &&
+		vmiMigration.Status.Phase != kubevirtv1.MigrationPending &&
+		vmiMigration.Status.Phase != kubevirtv1.MigrationScheduling {
 		klog.V(3).Infof("VirtualMachineInstanceMigration %s migration state is nil, skipping", key)
 		return nil
 	}
@@ -155,10 +159,17 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 	klog.Infof("collected port names of vmi %s, port names are %v", vmi.Name, strings.Join(portNames, ", "))
 
 	switch vmiMigration.Status.Phase {
-	case kubevirtv1.MigrationScheduling:
+	case kubevirtv1.MigrationPending, kubevirtv1.MigrationScheduling:
+		// KubeVirt creates the target virt-launcher in Pending and, for hotplug volumes,
+		// creates its attachment pod only after the launcher is ready. An attachment pod
+		// then gates Pending -> Scheduling, and both pods gate Scheduling -> Scheduled.
+		// Configure Pending to unblock launcher CNI and keep Scheduling for retries.
+		// Hotplug attachment pods share MigrationJobLabel, so AppLabel must distinguish
+		// the target virt-launcher whose NodeName identifies the migration target.
 		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				kubevirtv1.MigrationJobLabel: string(vmiMigration.UID),
+				kubevirtv1.AppLabel:          "virt-launcher",
 			},
 		})
 		if err != nil {
@@ -167,52 +178,52 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 			return err
 		}
 
-		pods, err := c.podsLister.Pods(vmiMigration.Namespace).List(selector)
+		launcherPods, err := c.podsLister.Pods(vmiMigration.Namespace).List(selector)
 		if err != nil {
-			err = fmt.Errorf("failed to list pods with migration job UID %s: %w", vmiMigration.UID, err)
+			err = fmt.Errorf("failed to list target launcher pods with migration job UID %s: %w", vmiMigration.UID, err)
 			klog.Error(err)
 			return err
 		}
 
-		if len(pods) > 0 {
-			targetPod := pods[0]
-			// During MigrationScheduling phase, use vmi.Status.NodeName if SourceNode is empty
-			// because vmi.Status.MigrationState may not be fully synchronized yet
+		if len(launcherPods) > 0 {
+			targetLauncherPod := launcherPods[0]
+			// Before MigrationState is synchronized, use the VMI's current node as the source.
 			sourceNode := srcNodeName
 			if sourceNode == "" {
 				sourceNode = vmi.Status.NodeName
 			}
 
-			if sourceNode == "" || targetPod.Spec.NodeName == "" || sourceNode == targetPod.Spec.NodeName {
-				klog.Warningf("VM pod %s/%s migration setup skipped, source node: %s, target node: %s (migration job UID: %s)",
-					targetPod.Namespace, targetPod.Name, sourceNode, targetPod.Spec.NodeName, vmiMigration.UID)
-				// The source or target node may not be known yet while the migration is still
-				// in the Scheduling phase; this produces no further phase-change event, so
-				// return an error to requeue with rate limiting and retry once scheduling
-				// completes, instead of dropping the event.
-				// https://github.com/kubeovn/kube-ovn/issues/6823
-				if sourceNode == "" || targetPod.Spec.NodeName == "" {
-					return fmt.Errorf("VM pod %s/%s migration setup deferred, source node %q, target node %q not ready yet (migration job UID %s)",
-						targetPod.Namespace, targetPod.Name, sourceNode, targetPod.Spec.NodeName, vmiMigration.UID)
-				}
+			if sourceNode == "" || targetLauncherPod.Spec.NodeName == "" {
+				klog.Warningf("target launcher pod %s/%s migration setup skipped, source node: %s, target node: %s (migration job UID: %s)",
+					targetLauncherPod.Namespace, targetLauncherPod.Name, sourceNode, targetLauncherPod.Spec.NodeName, vmiMigration.UID)
+				// Pod scheduling may complete without another VMIM phase update. Requeue until
+				// both node assignments are visible instead of dropping the pending setup.
+				return fmt.Errorf("target launcher pod %s/%s migration setup deferred, source node %q, target node %q not ready yet (migration job UID %s)",
+					targetLauncherPod.Namespace, targetLauncherPod.Name, sourceNode, targetLauncherPod.Spec.NodeName, vmiMigration.UID)
+			}
+			if sourceNode == targetLauncherPod.Spec.NodeName {
+				klog.Warningf("target launcher pod %s/%s migration setup skipped, source and target node are both %s (migration job UID: %s)",
+					targetLauncherPod.Namespace, targetLauncherPod.Name, sourceNode, vmiMigration.UID)
 				return nil
 			}
 
-			klog.Infof("VM pod %s/%s is migrating from %s to %s (migration job UID: %s)",
-				targetPod.Namespace, targetPod.Name, sourceNode, targetPod.Spec.NodeName, vmiMigration.UID)
+			klog.Infof("target launcher pod %s/%s is migrating from %s to %s (migration job UID: %s)",
+				targetLauncherPod.Namespace, targetLauncherPod.Name, sourceNode, targetLauncherPod.Spec.NodeName, vmiMigration.UID)
 
 			for _, portName := range portNames {
-				if err := c.OVNNbClient.SetLogicalSwitchPortMigrateOptions(portName, sourceNode, targetPod.Spec.NodeName); err != nil {
+				if err := c.OVNNbClient.SetLogicalSwitchPortMigrateOptions(portName, sourceNode, targetLauncherPod.Spec.NodeName); err != nil {
 					err = fmt.Errorf("failed to set migrate options for VM pod lsp %s: %w", portName, err)
 					klog.Error(err)
 					return err
 				}
-				klog.Infof("successfully set migrate options for lsp %s from %s to %s", portName, sourceNode, targetPod.Spec.NodeName)
+				klog.Infof("successfully set migrate options for lsp %s from %s to %s", portName, sourceNode, targetLauncherPod.Spec.NodeName)
 			}
 		} else {
-			klog.Warningf("target pod not yet created for migration job UID %s in phase %s, waiting for pod creation",
+			klog.Warningf("target launcher pod not yet created for migration job UID %s in phase %s, waiting for pod creation",
 				vmiMigration.UID, vmiMigration.Status.Phase)
-			return nil
+			// Target launcher pod creation does not necessarily change the VMIM phase.
+			// Requeue so the same Pending migration is retried after the pod appears.
+			return fmt.Errorf("target launcher pod not yet created for migration job UID %s in phase %s", vmiMigration.UID, vmiMigration.Status.Phase)
 		}
 	case kubevirtv1.MigrationSucceeded:
 		for _, portName := range portNames {

--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -106,10 +106,12 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 		return err
 	}
 	// MigrationState may still be nil before target virt-launcher pod handoff. Pending and
-	// Scheduling can derive both nodes without it, so allow network setup to proceed.
+	// Scheduling can derive both nodes without it, so allow network setup to proceed. Failed
+	// migrations also need to proceed so options configured while Pending can be cleaned up.
 	if vmiMigration.Status.MigrationState == nil &&
 		vmiMigration.Status.Phase != kubevirtv1.MigrationPending &&
-		vmiMigration.Status.Phase != kubevirtv1.MigrationScheduling {
+		vmiMigration.Status.Phase != kubevirtv1.MigrationScheduling &&
+		vmiMigration.Status.Phase != kubevirtv1.MigrationFailed {
 		klog.V(3).Infof("VirtualMachineInstanceMigration %s migration state is nil, skipping", key)
 		return nil
 	}
@@ -137,10 +139,13 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 		} else {
 			klog.Infof("current vmiMigration %s status %s, vmi MigrationState is nil", key, vmiMigration.Status.Phase)
 		}
-		// If we're at an end state and the vmi migration state is stale or nil, we're probably looking at an old migration
-		// either way, we can't proceed since we don't have the source and target nodes for resetting the migrate options
-		if vmiMigration.Status.Phase == kubevirtv1.MigrationSucceeded || vmiMigration.Status.Phase == kubevirtv1.MigrationFailed {
-			klog.V(3).Infof("VirtualMachineInstanceMigration %s migration state is Succeeded/Failed but VMI migration state is stale or nil, skipping", key)
+		// A failed migration may have configured options while Pending, before the VMI
+		// migration state was populated. The VMI's current node is still the source
+		// needed to roll back those options.
+		if vmiMigration.Status.Phase == kubevirtv1.MigrationFailed {
+			srcNodeName = vmi.Status.NodeName
+		} else if vmiMigration.Status.Phase == kubevirtv1.MigrationSucceeded {
+			klog.V(3).Infof("VirtualMachineInstanceMigration %s migration state is Succeeded but VMI migration state is stale or nil, skipping", key)
 			return nil
 		}
 	}

--- a/pkg/controller/kubevirt.go
+++ b/pkg/controller/kubevirt.go
@@ -142,9 +142,10 @@ func (c *Controller) handleAddOrUpdateVMIMigration(key string) error {
 		// A failed migration may have configured options while Pending, before the VMI
 		// migration state was populated. The VMI's current node is still the source
 		// needed to roll back those options.
-		if vmiMigration.Status.Phase == kubevirtv1.MigrationFailed {
+		switch vmiMigration.Status.Phase {
+		case kubevirtv1.MigrationFailed:
 			srcNodeName = vmi.Status.NodeName
-		} else if vmiMigration.Status.Phase == kubevirtv1.MigrationSucceeded {
+		case kubevirtv1.MigrationSucceeded:
 			klog.V(3).Infof("VirtualMachineInstanceMigration %s migration state is Succeeded but VMI migration state is stale or nil, skipping", key)
 			return nil
 		}

--- a/pkg/controller/kubevirt_test.go
+++ b/pkg/controller/kubevirt_test.go
@@ -116,3 +116,58 @@ func TestHandleAddOrUpdateVMIMigrationIgnoresHotplugAttachmentPod(t *testing.T) 
 	err = fc.fakeController.handleAddOrUpdateVMIMigration(namespace + "/" + migration)
 	require.ErrorContains(t, err, "target launcher pod not yet created")
 }
+
+func TestHandleAddOrUpdateVMIMigrationCleansFailedMigrationWithoutMigrationState(t *testing.T) {
+	const (
+		namespace  = "test"
+		migration  = "test-migration"
+		vmiName    = "test-vmi"
+		sourceNode = "source-node"
+		targetNode = "target-node"
+		portName   = "test-vmi.test"
+	)
+	migrationUID := types.UID("migration-uid")
+	targetLauncherPod := &corev1.Pod{
+		Name:      "virt-launcher-test-vmi-target",
+		Namespace: namespace,
+		Labels: map[string]string{
+			kubevirtv1.MigrationJobLabel: string(migrationUID),
+			kubevirtv1.AppLabel:          "virt-launcher",
+		},
+		Spec: corev1.PodSpec{NodeName: targetNode},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{targetLauncherPod}})
+	require.NoError(t, err)
+
+	mockCtrl := gomock.NewController(t)
+	kubevirtClient := kubecli.NewMockKubevirtClient(mockCtrl)
+	migrationClient := kubecli.NewMockVirtualMachineInstanceMigrationInterface(mockCtrl)
+	vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
+	fc.fakeController.config.KubevirtClient = kubevirtClient
+
+	vmiMigration := &kubevirtv1.VirtualMachineInstanceMigration{
+		Name: migration, Namespace: namespace, UID: migrationUID,
+		Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: vmiName},
+		Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+			Phase: kubevirtv1.MigrationPending,
+		},
+	}
+	vmi := &kubevirtv1.VirtualMachineInstance{
+		Name: vmiName, Namespace: namespace,
+		Status: kubevirtv1.VirtualMachineInstanceStatus{NodeName: sourceNode},
+	}
+
+	kubevirtClient.EXPECT().VirtualMachineInstanceMigration(namespace).Return(migrationClient).Times(2)
+	migrationClient.EXPECT().Get(gomock.Any(), migration, metav1.GetOptions{}).Return(vmiMigration, nil).Times(2)
+	kubevirtClient.EXPECT().VirtualMachineInstance(namespace).Return(vmiClient).Times(2)
+	vmiClient.EXPECT().Get(gomock.Any(), vmiName, metav1.GetOptions{}).Return(vmi, nil).Times(2)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(false, map[string]string{"pod": namespace + "/" + vmiName}).
+		Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil).Times(2)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortMigrateOptions(portName, sourceNode, targetNode).Return(nil)
+	fc.mockOvnClient.EXPECT().ResetLogicalSwitchPortMigrateOptions(portName, sourceNode, "", true).Return(nil)
+
+	require.NoError(t, fc.fakeController.handleAddOrUpdateVMIMigration(namespace+"/"+migration))
+	vmiMigration.Status.Phase = kubevirtv1.MigrationFailed
+	require.NoError(t, fc.fakeController.handleAddOrUpdateVMIMigration(namespace+"/"+migration))
+}

--- a/pkg/controller/kubevirt_test.go
+++ b/pkg/controller/kubevirt_test.go
@@ -8,10 +8,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 	"kubevirt.io/client-go/kubecli"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
+	"github.com/kubeovn/kube-ovn/pkg/informer"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 )
 
@@ -170,4 +172,62 @@ func TestHandleAddOrUpdateVMIMigrationCleansFailedMigrationWithoutMigrationState
 	require.NoError(t, fc.fakeController.handleAddOrUpdateVMIMigration(namespace+"/"+migration))
 	vmiMigration.Status.Phase = kubevirtv1.MigrationFailed
 	require.NoError(t, fc.fakeController.handleAddOrUpdateVMIMigration(namespace+"/"+migration))
+}
+
+func TestHandleAddOrUpdateVMIMigrationSkipsStaleFailedMigrationCleanup(t *testing.T) {
+	// Migration B has already installed its options when the delayed Failed event for migration A is processed.
+	const (
+		namespace  = "test"
+		vmiName    = "test-vmi"
+		sourceNode = "source-node"
+		targetNode = "target-node"
+		portName   = "test-vmi.test"
+	)
+	failedMigration := &kubevirtv1.VirtualMachineInstanceMigration{
+		Name: "failed-migration", Namespace: namespace, UID: types.UID("failed-migration-uid"),
+		Spec:   kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: vmiName},
+		Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{Phase: kubevirtv1.MigrationFailed},
+	}
+	pendingMigration := &kubevirtv1.VirtualMachineInstanceMigration{
+		Name: "pending-migration", Namespace: namespace, UID: types.UID("pending-migration-uid"),
+		Spec:   kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: vmiName},
+		Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{Phase: kubevirtv1.MigrationPending},
+	}
+	targetLauncherPod := &corev1.Pod{
+		Name:      "virt-launcher-test-vmi-target",
+		Namespace: namespace,
+		Labels: map[string]string{
+			kubevirtv1.MigrationJobLabel: string(pendingMigration.UID),
+			kubevirtv1.AppLabel:          "virt-launcher",
+		},
+		Spec: corev1.PodSpec{NodeName: targetNode},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{targetLauncherPod}})
+	require.NoError(t, err)
+	fc.fakeController.vmiMigrationIndexer = cache.NewIndexer(cache.MetaNamespaceKeyFunc, informer.GetVirtualMachineInstanceMigrationInformerIndexers())
+	require.NoError(t, fc.fakeController.vmiMigrationIndexer.Add(failedMigration))
+	require.NoError(t, fc.fakeController.vmiMigrationIndexer.Add(pendingMigration))
+
+	mockCtrl := gomock.NewController(t)
+	kubevirtClient := kubecli.NewMockKubevirtClient(mockCtrl)
+	migrationClient := kubecli.NewMockVirtualMachineInstanceMigrationInterface(mockCtrl)
+	vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
+	fc.fakeController.config.KubevirtClient = kubevirtClient
+	vmi := &kubevirtv1.VirtualMachineInstance{
+		Name: vmiName, Namespace: namespace,
+		Status: kubevirtv1.VirtualMachineInstanceStatus{NodeName: sourceNode},
+	}
+
+	kubevirtClient.EXPECT().VirtualMachineInstanceMigration(namespace).Return(migrationClient).Times(2)
+	migrationClient.EXPECT().Get(gomock.Any(), pendingMigration.Name, metav1.GetOptions{}).Return(pendingMigration, nil)
+	migrationClient.EXPECT().Get(gomock.Any(), failedMigration.Name, metav1.GetOptions{}).Return(failedMigration, nil)
+	kubevirtClient.EXPECT().VirtualMachineInstance(namespace).Return(vmiClient).Times(2)
+	vmiClient.EXPECT().Get(gomock.Any(), vmiName, metav1.GetOptions{}).Return(vmi, nil).Times(2)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(false, map[string]string{"pod": namespace + "/" + vmiName}).
+		Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortMigrateOptions(portName, sourceNode, targetNode).Return(nil)
+
+	require.NoError(t, fc.fakeController.handleAddOrUpdateVMIMigration(namespace+"/"+pendingMigration.Name))
+	require.NoError(t, fc.fakeController.handleAddOrUpdateVMIMigration(namespace+"/"+failedMigration.Name))
 }

--- a/pkg/controller/kubevirt_test.go
+++ b/pkg/controller/kubevirt_test.go
@@ -1,0 +1,118 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"kubevirt.io/client-go/kubecli"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
+)
+
+func TestHandleAddOrUpdateVMIMigrationConfiguresPendingMigration(t *testing.T) {
+	const (
+		namespace  = "test"
+		migration  = "test-migration"
+		vmiName    = "test-vmi"
+		sourceNode = "source-node"
+		targetNode = "target-node"
+		portName   = "test-vmi.test"
+	)
+	migrationUID := types.UID("migration-uid")
+	targetPod := &corev1.Pod{
+		Name:      "virt-launcher-test-vmi-target",
+		Namespace: namespace,
+		Labels: map[string]string{
+			kubevirtv1.MigrationJobLabel: string(migrationUID),
+			kubevirtv1.AppLabel:          "virt-launcher",
+		},
+		Spec: corev1.PodSpec{NodeName: targetNode},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{targetPod}})
+	require.NoError(t, err)
+
+	mockCtrl := gomock.NewController(t)
+	kubevirtClient := kubecli.NewMockKubevirtClient(mockCtrl)
+	migrationClient := kubecli.NewMockVirtualMachineInstanceMigrationInterface(mockCtrl)
+	vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
+	fc.fakeController.config.KubevirtClient = kubevirtClient
+
+	vmiMigration := &kubevirtv1.VirtualMachineInstanceMigration{
+		Name: migration, Namespace: namespace, UID: migrationUID,
+		Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: vmiName},
+		Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+			Phase: kubevirtv1.MigrationPending,
+		},
+	}
+	vmi := &kubevirtv1.VirtualMachineInstance{
+		Name: vmiName, Namespace: namespace,
+		Status: kubevirtv1.VirtualMachineInstanceStatus{NodeName: sourceNode},
+	}
+
+	kubevirtClient.EXPECT().VirtualMachineInstanceMigration(namespace).Return(migrationClient)
+	migrationClient.EXPECT().Get(gomock.Any(), migration, metav1.GetOptions{}).Return(vmiMigration, nil)
+	kubevirtClient.EXPECT().VirtualMachineInstance(namespace).Return(vmiClient)
+	vmiClient.EXPECT().Get(gomock.Any(), vmiName, metav1.GetOptions{}).Return(vmi, nil)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(false, map[string]string{"pod": namespace + "/" + vmiName}).
+		Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+	fc.mockOvnClient.EXPECT().SetLogicalSwitchPortMigrateOptions(portName, sourceNode, targetNode).Return(nil)
+
+	require.NoError(t, fc.fakeController.handleAddOrUpdateVMIMigration(namespace+"/"+migration))
+}
+
+func TestHandleAddOrUpdateVMIMigrationIgnoresHotplugAttachmentPod(t *testing.T) {
+	const (
+		namespace = "test"
+		migration = "test-migration"
+		vmiName   = "test-vmi"
+		portName  = "test-vmi.test"
+	)
+	migrationUID := types.UID("migration-uid")
+	attachmentPod := &corev1.Pod{
+		Name:      "hp-volume-test",
+		Namespace: namespace,
+		Labels: map[string]string{
+			kubevirtv1.MigrationJobLabel: string(migrationUID),
+			kubevirtv1.AppLabel:          "hotplug-disk",
+		},
+		Spec: corev1.PodSpec{NodeName: "target-node"},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{attachmentPod}})
+	require.NoError(t, err)
+
+	mockCtrl := gomock.NewController(t)
+	kubevirtClient := kubecli.NewMockKubevirtClient(mockCtrl)
+	migrationClient := kubecli.NewMockVirtualMachineInstanceMigrationInterface(mockCtrl)
+	vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
+	fc.fakeController.config.KubevirtClient = kubevirtClient
+
+	vmiMigration := &kubevirtv1.VirtualMachineInstanceMigration{
+		Name: migration, Namespace: namespace, UID: migrationUID,
+		Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{VMIName: vmiName},
+		Status: kubevirtv1.VirtualMachineInstanceMigrationStatus{
+			Phase: kubevirtv1.MigrationPending,
+		},
+	}
+	vmi := &kubevirtv1.VirtualMachineInstance{
+		Name: vmiName, Namespace: namespace,
+		Status: kubevirtv1.VirtualMachineInstanceStatus{NodeName: "source-node"},
+	}
+
+	kubevirtClient.EXPECT().VirtualMachineInstanceMigration(namespace).Return(migrationClient)
+	migrationClient.EXPECT().Get(gomock.Any(), migration, metav1.GetOptions{}).Return(vmiMigration, nil)
+	kubevirtClient.EXPECT().VirtualMachineInstance(namespace).Return(vmiClient)
+	vmiClient.EXPECT().Get(gomock.Any(), vmiName, metav1.GetOptions{}).Return(vmi, nil)
+	fc.mockOvnClient.EXPECT().ListNormalLogicalSwitchPorts(false, map[string]string{"pod": namespace + "/" + vmiName}).
+		Return([]ovnnb.LogicalSwitchPort{{Name: portName}}, nil)
+
+	err = fc.fakeController.handleAddOrUpdateVMIMigration(namespace + "/" + migration)
+	require.ErrorContains(t, err, "target launcher pod not yet created")
+}


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- [ ] Features
- [x] Bug fixes
- [ ] Docs
- [x] Tests

## Summary

KubeVirt creates the target `virt-launcher` while a VMI migration is still `Pending`. With hotplug volumes, the attachment pod is created only after that launcher becomes ready, and the migration cannot advance to `Scheduling` until the attachment pod is ready.

Kube-OVN previously configured OVN multi-chassis options only in `Scheduling`. The target launcher's CNI ADD needs those options to observe a stable `external_ids:ovn-installed=true`, creating a dependency cycle that can leave the migration in `Pending` with `ovs interface ... is not ready after 30s`.

This change:

- configures migration LSPs in both `Pending` and `Scheduling`;
- derives the source node from `VMI.status.nodeName` before the current `MigrationState` is available;
- selects the target launcher with both the migration job UID and `kubevirt.io=virt-launcher`, excluding hotplug attachment pods;
- requeues while the target launcher or its node assignment is not yet visible.

`Scheduling` remains an idempotent retry path, and terminal migration cleanup is unchanged.

## Why the failure was intermittent

In failed runs, the target interface exposed `ovn-installed=true` for only 6-9 ms before the flag was removed. Kube-OVN CNI polls the flag every 500 ms, so the old flow succeeded only when a poll happened to hit one of those short windows. Configuring `requested-chassis=source,target` in `Pending` removes that timing dependency.

## Verification

- `go test ./pkg/controller -count=1`
- `CI=true make lint`
- The equivalent downstream patch was validated in a fresh two-node kind cluster with KubeVirt v1.8.2: 12/12 bidirectional migrations with RWX root and hotplug data volumes succeeded, including after retaining 12 completed launcher pods.
- No `ovs interface ... is not ready after 30s` errors were observed after the fix.

## Which issue(s) this PR fixes

Fixes #7416.
