### PR TITLE
fix(pinger,monitor): allow monitoring/metrics components to find correct ctrl sockets

### DIFF
--- a/pkg/ovn_leader_checker/ovn.go
+++ b/pkg/ovn_leader_checker/ovn.go
@@ -39,7 +39,6 @@ import (
 
 const (
 	OvnNorthdServiceName           = "ovn-northd"
-	OvnNorthdPid                   = "/var/run/ovn/ovn-northd.pid"
 	DefaultProbeInterval           = 5
 	MaxFailCount                   = 3
 	maxDuplicateLeaderObservations = 3
@@ -263,7 +262,7 @@ func isDBLeader(address, database string) (bool, error) {
 }
 
 func checkNorthdActive() bool {
-	output, err := ovs.Appctl("ovn-northd", "status")
+	output, err := ovs.Appctl(ovs.OvnNorthd, "status")
 	if err != nil {
 		klog.Errorf("checkNorthdActive execute err %v error msg %v", err, output)
 		return false

--- a/pkg/ovnmonitor/util.go
+++ b/pkg/ovnmonitor/util.go
@@ -42,7 +42,7 @@ func (e *Exporter) getOvnStatus() map[string]int {
 	result["ovsdb-server-southbound"] = parseDbStatus(output)
 
 	// get ovn-northd status
-	if output, err = ovs.Appctl("ovn-northd", "status"); err != nil {
+	if output, err = ovs.Appctl(ovs.OvnNorthd, "status"); err != nil {
 		klog.Errorf("get ovn-northd status failed, err %v", err)
 		result["ovn-northd"] = 0
 	} else if len(strings.Split(output, ":")) != 2 {

--- a/pkg/ovs/ovs-appctl.go
+++ b/pkg/ovs/ovs-appctl.go
@@ -4,4 +4,5 @@ const (
 	OvsdbServer   = "ovsdb-server"
 	OvsVswitchd   = "ovs-vswitchd"
 	OvnController = "ovn-controller"
+	OvnNorthd     = "ovn-northd"
 )

--- a/pkg/ovs/ovs-appctl_linux.go
+++ b/pkg/ovs/ovs-appctl_linux.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -12,11 +13,14 @@ import (
 )
 
 const (
+	ovsRunDir = "/var/run/openvswitch"
+	ovnRunDir = "/var/run/ovn"
+
 	cmdOvsAppctl = "ovs-appctl"
 	cmdOvnAppctl = "ovn-appctl"
 
-	ovnNBCtlSocket = "/var/run/ovn/ovnnb_db.ctl"
-	ovnSBCtlSocket = "/var/run/ovn/ovnsb_db.ctl"
+	ovnNBCtlSocket = ovnRunDir + "/ovnnb_db.ctl"
+	ovnSBCtlSocket = ovnRunDir + "/ovnsb_db.ctl"
 )
 
 func appctlByTarget(appctlCmd, target, command string, args ...string) (string, error) {
@@ -27,6 +31,52 @@ func appctlByTarget(appctlCmd, target, command string, args ...string) (string, 
 		return "", fmt.Errorf("failed to run command %q: %w", cmd.String(), err)
 	}
 	return string(output), nil
+}
+
+// componentRunDir maps a component to the runtime directory holding its pid file and
+// control socket. Only daemons whose control socket is suffixed with their pid belong
+// here: the ovsdb-server processes serving the OVN databases listen on a fixed socket
+// path instead and must be reached through OvnDatabaseControl.
+var componentRunDir = map[string]string{
+	OvsdbServer:   ovsRunDir,
+	OvsVswitchd:   ovsRunDir,
+	OvnController: ovnRunDir,
+	OvnNorthd:     ovnRunDir,
+}
+
+func runDirOfComponent(component string) (string, error) {
+	runDir, ok := componentRunDir[component]
+	if !ok {
+		return "", fmt.Errorf("unknown component %q", component)
+	}
+	return runDir, nil
+}
+
+func ctlSocketPathIn(runDir, component string) (string, error) {
+	pidFile := filepath.Join(runDir, component+".pid")
+	pidBytes, err := os.ReadFile(pidFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read pid file %q: %w", pidFile, err)
+	}
+	pidFields := strings.Fields(string(pidBytes))
+	if len(pidFields) == 0 {
+		return "", fmt.Errorf("pid file %q is empty or contains only whitespace", pidFile)
+	}
+
+	return filepath.Join(runDir, fmt.Sprintf("%s.%s.ctl", component, pidFields[0])), nil
+}
+
+// ctlSocketPath resolves the control socket path of the given component by reading its pid file.
+// We must not let ovs-appctl/ovn-appctl resolve a bare component name on their own:
+// they open the pid file for writing and take the pid from fcntl(F_GETLK) instead of
+// the file content, so the resolution fails for a non-root user as well as for a
+// component running in another pid namespace, where the kernel reports the lock owner as pid 0.
+func ctlSocketPath(component string) (string, error) {
+	runDir, err := runDirOfComponent(component)
+	if err != nil {
+		return "", err
+	}
+	return ctlSocketPathIn(runDir, component)
 }
 
 // OvnDatabaseControl sends a command to the specified OVN database control socket
@@ -44,17 +94,21 @@ func OvnDatabaseControl(db, command string, args ...string) (string, error) {
 	return Appctl(socket, command, args...)
 }
 
+// Appctl sends a command to an ovs/ovn daemon. The target is either an absolute
+// path of a control socket, or the name of a component whose control socket is
+// resolved from its pid file.
 func Appctl(target, command string, args ...string) (string, error) {
-	var cmd string
-	switch {
-	case strings.IndexRune(target, os.PathSeparator) == 0:
-		fallthrough
-	case strings.HasPrefix(target, "ovn"):
+	if !filepath.IsAbs(target) {
+		socket, err := ctlSocketPath(target)
+		if err != nil {
+			return "", err
+		}
+		target = socket
+	}
+
+	cmd := cmdOvsAppctl
+	if strings.HasPrefix(target, ovnRunDir+string(os.PathSeparator)) {
 		cmd = cmdOvnAppctl
-	case strings.HasPrefix(target, "ovs"):
-		cmd = cmdOvsAppctl
-	default:
-		return "", fmt.Errorf("unknown target %q", target)
 	}
 
 	return appctlByTarget(cmd, target, command, args...)

--- a/pkg/ovs/ovs-appctl_linux_test.go
+++ b/pkg/ovs/ovs-appctl_linux_test.go
@@ -1,0 +1,109 @@
+package ovs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunDirOfComponent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		component string
+		runDir    string
+		wantErr   bool
+	}{
+		{name: "ovsdb-server", component: OvsdbServer, runDir: ovsRunDir},
+		{name: "ovs-vswitchd", component: OvsVswitchd, runDir: ovsRunDir},
+		{name: "ovn-controller", component: OvnController, runDir: ovnRunDir},
+		{name: "ovn-northd", component: OvnNorthd, runDir: ovnRunDir},
+		{name: "unknown component", component: "foo", wantErr: true},
+		{name: "empty component", component: "", wantErr: true},
+		{name: "ovn nb database", component: "ovnnb_db", wantErr: true},
+		{name: "ovn sb database", component: "ovnsb_db", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runDir, err := runDirOfComponent(tt.component)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.runDir, runDir)
+		})
+	}
+}
+
+func TestCtlSocketPathIn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		socket  string
+		wantErr string
+	}{
+		// the pid is taken from the file content as is, so a pid written by a daemon
+		// running in another pid namespace or as another user is honored
+		{name: "plain pid", content: "12345", socket: "ovs-vswitchd.12345.ctl"},
+		{name: "trailing newline", content: "12345\n", socket: "ovs-vswitchd.12345.ctl"},
+		{name: "surrounding whitespace", content: " 12345 \n", socket: "ovs-vswitchd.12345.ctl"},
+		{name: "empty", content: "", wantErr: "is empty or contains only whitespace"},
+		{name: "whitespace only", content: "\n", wantErr: "is empty or contains only whitespace"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runDir := t.TempDir()
+			pidFile := filepath.Join(runDir, OvsVswitchd+".pid")
+			require.NoError(t, os.WriteFile(pidFile, []byte(tt.content), 0o600))
+
+			socket, err := ctlSocketPathIn(runDir, OvsVswitchd)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, filepath.Join(runDir, tt.socket), socket)
+		})
+	}
+}
+
+func TestCtlSocketPathInMissingPidFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := ctlSocketPathIn(t.TempDir(), OvsVswitchd)
+	require.ErrorContains(t, err, "failed to read pid file")
+}
+
+func TestCtlSocketPathErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := ctlSocketPath("foo")
+	require.ErrorContains(t, err, `unknown component "foo"`)
+
+	_, err = ctlSocketPath("ovnnb_db")
+	require.ErrorContains(t, err, `unknown component "ovnnb_db"`)
+}
+
+func TestOvnDatabaseControlUnknownDB(t *testing.T) {
+	t.Parallel()
+
+	_, err := OvnDatabaseControl("foo", "cluster/status")
+	require.ErrorContains(t, err, `unknown db "foo"`)
+}
+
+func TestAppctlUnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	_, err := Appctl("foo", "version")
+	require.ErrorContains(t, err, `unknown component "foo"`)
+}

--- a/test/e2e/kube-ovn/e2e_test.go
+++ b/test/e2e/kube-ovn/e2e_test.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/crd"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/ipam"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/kubectl-ko"
+	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/metrics"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/network-policy"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/nftables"
 	_ "github.com/kubeovn/kube-ovn/test/e2e/kube-ovn/node"

--- a/test/e2e/kube-ovn/metrics/metrics.go
+++ b/test/e2e/kube-ovn/metrics/metrics.go
@@ -1,0 +1,187 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+)
+
+const (
+	// the exporters populate their gauges on a polling loop, so a scrape right after
+	// the pod has started may not expose the samples we are looking for yet
+	scrapeInterval = 2 * time.Second
+	scrapeTimeout  = time.Minute
+)
+
+// sampleValue returns the value of the first sample of the given metric whose line contains
+// all the given labels, e.g. `hostname="node1"`. Matching the labels individually keeps the
+// lookup working whatever their order is and whenever a new label is added to the metric.
+func sampleValue(metrics, name string, labels ...string) (float64, bool) {
+	for line := range strings.Lines(metrics) {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, name+"{") && !strings.HasPrefix(line, name+" ") {
+			continue
+		}
+		if slices.ContainsFunc(labels, func(label string) bool { return !strings.Contains(line, label) }) {
+			continue
+		}
+		// the value is the last field: a label value may contain spaces
+		index := strings.LastIndexByte(line, ' ')
+		if index < 0 {
+			continue
+		}
+		if value, err := strconv.ParseFloat(line[index+1:], 64); err == nil {
+			return value, true
+		}
+	}
+	return 0, false
+}
+
+// predicate is an assertion on the value of a sample.
+type predicate struct {
+	desc  string
+	match func(float64) bool
+}
+
+func equalTo(expected float64) predicate {
+	return predicate{
+		desc:  fmt.Sprintf("to be %v", expected),
+		match: func(value float64) bool { return value == expected },
+	}
+}
+
+func oneOf(expected ...float64) predicate {
+	return predicate{
+		desc:  fmt.Sprintf("to be one of %v", expected),
+		match: func(value float64) bool { return slices.Contains(expected, value) },
+	}
+}
+
+func nonZero() predicate {
+	return predicate{
+		desc:  "to be non-zero",
+		match: func(value float64) bool { return value != 0 },
+	}
+}
+
+// expectation is an assertion on the sample of a metric identified by its labels.
+type expectation struct {
+	name   string
+	labels []string
+	pred   predicate
+}
+
+func (e expectation) String() string {
+	return fmt.Sprintf("%s{%s}", e.name, strings.Join(e.labels, ","))
+}
+
+// waitForMetrics scrapes the metrics exposed by the given container from within the pod
+// itself until all the expectations are met.
+func waitForMetrics(f *framework.Framework, pod *corev1.Pod, container, port string, secure bool, expectations []expectation) {
+	ginkgo.GinkgoHelper()
+
+	scheme, curlArgs := "http", "-fsS"
+	if secure {
+		scheme, curlArgs = "https", "-fsSk"
+	}
+	url := fmt.Sprintf("%s://%s/metrics", scheme, net.JoinHostPort(pod.Status.PodIP, port))
+
+	framework.WaitUntil(scrapeInterval, scrapeTimeout, func(_ context.Context) (bool, error) {
+		metrics, _, err := framework.ExecShellInContainer(f, pod.Namespace, pod.Name, container, "curl "+curlArgs+" "+url)
+		if err != nil {
+			framework.Logf("failed to scrape %s: %v", url, err)
+			return false, nil
+		}
+
+		for _, e := range expectations {
+			value, ok := sampleValue(metrics, e.name, e.labels...)
+			if !ok {
+				framework.Logf("sample %s has not been exposed yet", e)
+				return false, nil
+			}
+			if !e.pred.match(value) {
+				framework.Logf("expected sample %s %s, got %v", e, e.pred.desc, value)
+				return false, nil
+			}
+		}
+		return true, nil
+	}, fmt.Sprintf("metrics exposed at %s to meet all the expectations", url))
+}
+
+var _ = framework.Describe("[group:metrics]", func() {
+	f := framework.NewDefaultFramework("metrics")
+
+	// kube-ovn-pinger runs with hostPID disabled and as a non-root user, so it must resolve
+	// the control socket of the ovs/ovn daemons from their pid files by itself
+	framework.ConformanceIt("kube-ovn-pinger should report ovs and ovn-controller as up", func() {
+		daemonSetClient := f.DaemonSetClientNS(framework.KubeOvnNamespace)
+		pods, err := daemonSetClient.GetPods(daemonSetClient.Get("kube-ovn-pinger"))
+		framework.ExpectNoError(err)
+		framework.ExpectNotEmpty(pods.Items)
+
+		for _, pod := range pods.Items {
+			node := fmt.Sprintf("%q", pod.Spec.NodeName)
+			ginkgo.By("Checking metrics exposed by pinger pod " + pod.Name + " on node " + pod.Spec.NodeName)
+			expectations := []expectation{
+				{name: "pinger_ovs_up", labels: []string{"nodeName=" + node}, pred: equalTo(1)},
+				{name: "pinger_ovs_down", labels: []string{"nodeName=" + node}, pred: equalTo(0)},
+				{name: "pinger_ovn_controller_up", labels: []string{"nodeName=" + node}, pred: equalTo(1)},
+				{name: "pinger_ovn_controller_down", labels: []string{"nodeName=" + node}, pred: equalTo(0)},
+				// collected from ovs-vswitchd via dpctl/dump-dps
+				{name: "kube_ovn_dp_total", labels: []string{"hostname=" + node}, pred: nonZero()},
+			}
+			for _, component := range []string{"ovsdb-server", "ovs-vswitchd"} {
+				expectations = append(expectations, expectation{
+					name:   "kube_ovn_ovs_status",
+					labels: []string{fmt.Sprintf("component=%q", component), "hostname=" + node},
+					pred:   equalTo(1),
+				})
+			}
+			waitForMetrics(f, &pod, "pinger", "8080", false, expectations)
+		}
+	})
+
+	// kube-ovn-monitor runs in a pod of its own, so it must not rely on sharing a pid
+	// namespace with ovn-northd to reach its control socket
+	framework.ConformanceIt("kube-ovn-monitor should report ovn-northd as healthy", func() {
+		deploymentClient := f.DeploymentClientNS(framework.KubeOvnNamespace)
+		deploy := deploymentClient.Get("kube-ovn-monitor")
+		pods, err := deploymentClient.GetPods(deploy)
+		framework.ExpectNoError(err)
+		framework.ExpectNotEmpty(pods.Items)
+
+		const container = "kube-ovn-monitor"
+		secure := false
+		for _, c := range deploy.Spec.Template.Spec.Containers {
+			if c.Name == container {
+				secure = slices.Contains(c.Args, "--secure-serving=true")
+				break
+			}
+		}
+
+		for _, pod := range pods.Items {
+			node := fmt.Sprintf("%q", pod.Spec.NodeName)
+			ginkgo.By("Checking metrics exposed by monitor pod " + pod.Name + " on node " + pod.Spec.NodeName)
+			// 1 stands for active/leader and 2 for standby/follower, 0 means unhealthy
+			var expectations []expectation
+			for _, component := range []string{"ovn-northd", "ovsdb-server-northbound", "ovsdb-server-southbound"} {
+				expectations = append(expectations, expectation{
+					name:   "kube_ovn_ovn_status",
+					labels: []string{fmt.Sprintf("component=%q", component), "hostname=" + node},
+					pred:   oneOf(1, 2),
+				})
+			}
+			waitForMetrics(f, &pod, container, "10661", secure, expectations)
+		}
+	})
+})


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Bug fixes
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

Since #6230, kube-ovn-pinger and kube-ovn-monitor cannot reach the control sockets of the OVS/OVN daemons, so their health metrics are permanently stuck at "down" even on a fully healthy cluster.

#6230 removed the Go-side pid file resolution added by #5973 and let ovs-appctl/ovn-appctl resolve a bare daemon name themselves. That resolution cannot work from these two pods.

ovs-appctl resolves a non-absolute `--target` via `read_pidfile()` (utilities/ovs-appctl.c):

```
  pidfile_name = xasprintf("%s/%s.pid", ovs_rundir(), target);
  pid = read_pidfile(pidfile_name);
  socket_name = xasprintf("%s/%s.%ld.ctl", ovs_rundir(), target, (long int) pid);
```

and `read_pidfile__()` (lib/daemon-unix.c) does not use the file's contents:

```
  file = fopen(pidfile_, "r+");
  ...
  if (lck.l_pid != strtoul(line, NULL, 10)) {
      error = ESRCH;
      VLOG_WARN("%s: stale pidfile for pid %s being deleted by pid %ld", ...);
```

This fails for two reasons:
1. `fcntl(F_GETLK).l_pid` is translated through locks_translate_pid(), which returns 0 when the lock owner is in a namespace that is not an ancestor of the caller's. Both pods run with hostPID: false, while the daemons live in ovs-ovn (hostPID: true) and ovn-central. So l_pid is 0, never matches the pid in the file, and the lookup fails with ESRCH.

2. The pid file is 0644 root:root, but `read_pidfile__` opens it "r+". Both pods run as uid 65534 (kubeovn.runAsUser), so the open fails with EACCES. This blocks the lookup even where the PID namespace is shared.

The control sockets themselves are reachable so the issue is just in the pid resolution.

This is fixed by reading the pidfile in Go instead of delegating to ovs-appctl/ovn-appctl.

## Which issue(s) this PR fixes

Fixes #7417
