### PR TITLE
fix(test): persist FRR BGP topology configuration

### DIFF
--- a/yamls/clab-bgp-ha.yaml.j2
+++ b/yamls/clab-bgp-ha.yaml.j2
@@ -43,7 +43,8 @@ topology:
          -c ' address-family ipv4 unicast'
          -c '   redistribute connected'
          -c '  exit-address-family'
-         -c '!'
+         -c 'end'
+         -c 'write memory'
     router-2:
       kind: linux
       image: {{ frr_image }}
@@ -69,7 +70,8 @@ topology:
          -c ' address-family ipv4 unicast'
          -c '   redistribute connected'
          -c '  exit-address-family'
-         -c '!'
+         -c 'end'
+         -c 'write memory'
     kube-ovn-control-plane:
       kind: ext-container
       exec:

--- a/yamls/clab-bgp.yaml.j2
+++ b/yamls/clab-bgp.yaml.j2
@@ -70,7 +70,8 @@ topology:
          -c '   redistribute connected'
          -c '  exit-address-family'
 {%- endif %}
-         -c '!'
+         -c 'end'
+         -c 'write memory'
     kube-ovn-control-plane:
       kind: ext-container
       exec:


### PR DESCRIPTION
## Summary

- persist the containerlab FRR BGP configuration after provisioning
- apply the same restart-safe behavior to both the standard and HA BGP topologies

## Root cause

The topology templates configured FRR only in memory. If `watchfrr` restarted `bgpd`, the daemon had no saved BGP configuration to reload. FRR then returned `Default BGP instance not found`, while all speaker pods stayed healthy and kept retrying their configured neighbors. This caused every BGP speaker E2E case to time out in `BeforeEach`.

Failures reproduced in:

- https://github.com/kubeovn/kube-ovn/actions/runs/34694120809/job/103557186285
- https://github.com/kubeovn/kube-ovn/actions/runs/33756669551/job/100656247777

## Validation

- Rendered `clab-bgp.yaml.j2` for IPv4, IPv6, and dual-stack and parsed each result as YAML
- Rendered and parsed `clab-bgp-ha.yaml.j2`
- Replayed the rendered dual-stack FRR command against `quay.io/frrouting/frr:9.1.3`, restarted `bgpd`, and verified AS 65001 plus all four peers were restored
- `make lint`
- `go test ./test/e2e/bgp -run "Test(PeersForFamily|WorkerSourceAddress|RoutePathsFromRoute|ReadFRRRoute)" -count=1`