### PR TITLE
fix(dhcp): keep commas inside braced DHCP option values

### DIFF
--- a/pkg/ovs/util.go
+++ b/pkg/ovs/util.go
@@ -169,6 +169,35 @@ func formatDHCPOptions(options map[string]string) string {
 	return sb.String()
 }
 
+// splitDHCPOptions splits the raw option string on commas,
+// commas inside braces are part of the value and do not split,
+// e.g. router=10.0.0.1,classless_static_route={10.0.0.0/24,10.0.0.1}
+func splitDHCPOptions(raw string) []string {
+	var options []string
+	depth, start := 0, 0
+	for i, c := range raw {
+		switch c {
+		case '{':
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				options = append(options, raw[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if depth != 0 {
+		// unbalanced braces, fall back to a plain split so that a malformed
+		// value does not swallow the options following it
+		return strings.Split(raw, ",")
+	}
+	return append(options, raw[start:])
+}
+
 // parseDHCPOptions parses dhcp options,
 // the raw option's format is: server_id=192.168.123.50,server_mac=00:00:00:08:0a:11
 func parseDHCPOptions(raw string) map[string]string {
@@ -181,8 +210,7 @@ func parseDHCPOptions(raw string) map[string]string {
 
 	// trim blank
 	raw = strings.ReplaceAll(raw, " ", "")
-	options := strings.SplitSeq(raw, ",")
-	for option := range options {
+	for _, option := range splitDHCPOptions(raw) {
 		kv := strings.Split(option, "=")
 		// TODO: ignore invalidate option, maybe need further validation
 		if len(kv) != 2 || len(kv[0]) == 0 || len(kv[1]) == 0 {

--- a/pkg/ovs/util_test.go
+++ b/pkg/ovs/util_test.go
@@ -70,6 +70,38 @@ func Test_parseDHCPOptions(t *testing.T) {
 		}
 		require.Equal(t, expected, result)
 	})
+
+	t.Run("braced values with commas", func(t *testing.T) {
+		t.Parallel()
+		result := parseDHCPOptions("router=10.0.0.1,classless_static_route={10.0.0.0/24,10.0.0.1,0.0.0.0/0,10.0.0.254},dns_server={8.8.8.8,8.8.4.4},lease_time=3600")
+		expected := map[string]string{
+			"router":                 "10.0.0.1",
+			"classless_static_route": "{10.0.0.0/24,10.0.0.1,0.0.0.0/0,10.0.0.254}",
+			"dns_server":             "{8.8.8.8,8.8.4.4}",
+			"lease_time":             "3600",
+		}
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("semicolon is kept in scalar values", func(t *testing.T) {
+		t.Parallel()
+		result := parseDHCPOptions("wpad=http://example.test/a;b,router=10.0.0.1")
+		expected := map[string]string{
+			"wpad":   "http://example.test/a;b",
+			"router": "10.0.0.1",
+		}
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("unbalanced braces do not swallow following options", func(t *testing.T) {
+		t.Parallel()
+		result := parseDHCPOptions("classless_static_route={10.0.0.0/24,router=10.0.0.1")
+		expected := map[string]string{
+			"classless_static_route": "{10.0.0.0/24",
+			"router":                 "10.0.0.1",
+		}
+		require.Equal(t, expected, result)
+	})
 }
 
 func Test_getIpv6Prefix(t *testing.T) {
@@ -540,6 +572,13 @@ func TestFormatDHCPOptions(t *testing.T) {
 				"dns_server": "{8.8.8.8,1.1.1.1}",
 			},
 			expected: "dns_server={8.8.8.8;1.1.1.1}",
+		},
+		{
+			name: "classless static route keeps commas inside braces",
+			options: map[string]string{
+				"classless_static_route": "{10.0.0.0/24,10.0.0.1}",
+			},
+			expected: "classless_static_route={10.0.0.0/24,10.0.0.1}",
 		},
 	}
 


### PR DESCRIPTION
# Pull Request

- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

- Bug fixes
- Tests

`parseDHCPOptions` splits the raw option string on every comma. Only `dns_server` can carry a list, via a `;` escape that is translated back to `,` for that key alone. Any other value containing a comma is truncated at the first comma and the remainder silently dropped.

This makes option 121 (`classless_static_route`) impossible to deliver: its OVN format always contains a comma, even for a single route, so

```
classless_static_route={10.0.0.0/24,10.0.0.1}
```

is stored as `classless_static_route={10.0.0.0/24`, the `10.0.0.1}` tail is discarded, `router` is then re-injected from the subnet gateway, and OVN can reject the malformed entry, leaving the port without DHCP at all. The same applies to every other list-valued option (`ntp_server`, `log_server`, `domain_search_list`, `ms_classless_static_route`, DHCPv6 `domain_search`).

Motivation: multi-NIC KubeVirt VMs with managedTap need a default route on exactly one interface. `router` is a mandatory option and is always re-injected, so it cannot be suppressed; option 121 is the standard way to do this (RFC 3442: a client that understands 121 must ignore option 3).

### Change

The split is now brace-aware: commas inside `{...}` are part of the value, so list options can be written in their native OVN form. Nothing else changes:

- the `dns_server` `;` escape is kept as is for compatibility;
- scalar values are passed through untouched, so `wpad=http://example.test/a;b` round-trips unchanged;
- unbalanced braces fall back to the plain comma split, so a malformed value cannot swallow the options following it.

Unit tests cover braced values in `parseDHCPOptions` and `formatDHCPOptions`, semicolons in scalar values, and the unbalanced-brace fallback.

## Which issue(s) this PR fixes

N/A
