### PR TITLE
test(e2e): tolerate asynchronous iptables chain creation

### DIFF
--- a/test/e2e/framework/iptables/iptables.go
+++ b/test/e2e/framework/iptables/iptables.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 )
 
-func CheckIptablesRulesOnNode(f *framework.Framework, node, table, chain, protocol string, expectedRules []string, shouldExist bool) {
+func CheckIptablesRulesOnNode(f *framework.Framework, node, table, _ string, protocol string, expectedRules []string, shouldExist bool) {
 	ovsPod := getOvsPodOnNode(f, node)
 
 	iptBin := "iptables"
@@ -24,22 +24,32 @@ func CheckIptablesRulesOnNode(f *framework.Framework, node, table, chain, protoc
 		iptBin = "ip6tables"
 	}
 
+	// Query the full table so a chain that is still being created does not
+	// turn an expected transient state into an iptables command failure.
 	cmd := fmt.Sprintf(`%s -t %s -S`, iptBin, table)
-	if chain != "" {
-		cmd += chain
-	}
 	framework.WaitUntil(time.Second, time.Minute, func(_ context.Context) (bool, error) {
-		output := e2epodoutput.RunHostCmdOrDie(ovsPod.Namespace, ovsPod.Name, cmd)
-		rules := strings.Split(output, "\n")
-		for _, r := range expectedRules {
-			framework.Logf("checking rule %s", r)
-			ok, err := gomega.ContainElement(gomega.HavePrefix(r)).Match(rules)
-			if err != nil || ok != shouldExist {
-				return false, err
-			}
+		output, err := e2epodoutput.RunHostCmd(ovsPod.Namespace, ovsPod.Name, cmd)
+		if err != nil {
+			// The tproxy worker creates and removes chains asynchronously. Keep
+			// polling if the host command is temporarily unavailable while the
+			// desired rule is converging.
+			framework.Logf("failed to read iptables rules, retrying: %v", err)
+			return false, nil
 		}
-		return true, nil
+
+		return matchRules(output, expectedRules, shouldExist)
 	}, "")
+}
+
+func matchRules(output string, expectedRules []string, shouldExist bool) (bool, error) {
+	rules := strings.Split(output, "\n")
+	for _, r := range expectedRules {
+		ok, err := gomega.ContainElement(gomega.HavePrefix(r)).Match(rules)
+		if err != nil || ok != shouldExist {
+			return false, err
+		}
+	}
+	return true, nil
 }
 
 func getOvsPodOnNode(f *framework.Framework, node string) *corev1.Pod {

--- a/test/e2e/framework/iptables/iptables.go
+++ b/test/e2e/framework/iptables/iptables.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubeovn/kube-ovn/test/e2e/framework"
 )
 
-func CheckIptablesRulesOnNode(f *framework.Framework, node, table, _ string, protocol string, expectedRules []string, shouldExist bool) {
+func CheckIptablesRulesOnNode(f *framework.Framework, node, table, _, protocol string, expectedRules []string, shouldExist bool) {
 	ovsPod := getOvsPodOnNode(f, node)
 
 	iptBin := "iptables"

--- a/test/e2e/framework/iptables/iptables_test.go
+++ b/test/e2e/framework/iptables/iptables_test.go
@@ -1,0 +1,47 @@
+package iptables
+
+import "testing"
+
+func TestMatchRules(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		expected    []string
+		shouldExist bool
+		wantMatched bool
+	}{
+		{
+			name:        "rule present",
+			output:      "-A OVN-OUTPUT -d 2001:db8::1/128 -p tcp --dport 8080 -j MARK\n",
+			expected:    []string{"-A OVN-OUTPUT -d 2001:db8::1/128 -p tcp --dport 8080"},
+			shouldExist: true,
+			wantMatched: true,
+		},
+		{
+			name:        "chain not created yet",
+			output:      "",
+			expected:    []string{"-A OVN-OUTPUT -d 2001:db8::1/128 -p tcp --dport 8080"},
+			shouldExist: true,
+			wantMatched: false,
+		},
+		{
+			name:        "rule absent",
+			output:      "-A OVN-OUTPUT -d 2001:db8::1/128 -p tcp --dport 8080 -j MARK\n",
+			expected:    []string{"-A OVN-OUTPUT -d 2001:db8::1/128 -p tcp --dport 9090"},
+			shouldExist: false,
+			wantMatched: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, err := matchRules(tt.output, tt.expected, tt.shouldExist)
+			if err != nil {
+				t.Fatalf("matchRules returned error: %v", err)
+			}
+			if matched != tt.wantMatched {
+				t.Fatalf("matchRules = %v, want %v", matched, tt.wantMatched)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Avoid failing the VPC pod probe E2E when tproxy iptables chains are still being created.
- Query the full iptables table and retry transient host-command failures instead of using `RunHostCmdOrDie` on a missing chain.
- Add regression coverage for pending, present, and absent rules.

The original failure was observed in [Actions run 34694120809, job 103557186091](https://github.com/kubeovn/kube-ovn/actions/runs/34694120809/job/103557186091), where `ip6tables -SOVN-OUTPUT` returned `No chain/target/match by that name`.

## Validation

- `go test ./test/e2e/framework/iptables -count=1`
- `go vet ./test/e2e/framework/iptables`
- `go test ./test/e2e/kube-ovn/pod -run '^$'`\n- `git diff --check`\n\nSigned-off-by: zhangzujian <zhangzujian.7@gmail.com>