### PR TITLE
test(e2e): preserve OVN interconnection spec order

### DIFF
--- a/hack/test_e2e_selector.py
+++ b/hack/test_e2e_selector.py
@@ -730,6 +730,17 @@ class E2ESelectorTest(unittest.TestCase):
                     f"{path} silently selected smoke only",
                 )
 
+    def testOvnICSpecsAreOrdered(self):
+        source = (repoRoot / "test/e2e/ovn-ic/e2e_test.go").read_text()
+        self.assertIn(
+            'framework.OrderedDescribe("[group:ovn-ic]"',
+            source,
+        )
+        self.assertNotIn(
+            'framework.SerialDescribe("[group:ovn-ic]"',
+            source,
+        )
+
     def testSharedE2EFrameworkPromotesToFull(self):
         plan = self.select(["test/e2e/framework/pod.go"])
 

--- a/test/e2e/ovn-ic/e2e_test.go
+++ b/test/e2e/ovn-ic/e2e_test.go
@@ -76,7 +76,8 @@ func execPodOrDie(kubeContext, namespace, pod, cmd string) string {
 	return e2epodoutput.RunHostCmdOrDie(namespace, pod, cmd)
 }
 
-var _ = framework.SerialDescribe("[group:ovn-ic]", func() {
+// The specs mutate shared interconnection state and must run in declaration order.
+var _ = framework.OrderedDescribe("[group:ovn-ic]", func() {
 	frameworks := make([]*framework.Framework, len(clusters))
 	for i := range clusters {
 		frameworks[i] = framework.NewFrameworkWithContext("ovn-ic", "kind-"+clusters[i])


### PR DESCRIPTION
## Summary

- mark the stateful OVN interconnection E2E container as ordered
- add a selector regression check to keep the ordering contract explicit

## Root cause

Job [103597197327](https://github.com/kubeovn/kube-ovn/actions/runs/34709224263/job/103597197327) enabled Ginkgo `--randomize-all` for four specs that mutate shared interconnection state. That attempt ran `should be able to update az name` before the baseline switch and communication checks, leaving `az7926` in OVN while later specs still asserted `ts-az0` and zero ECMP routes. The same job had no install or restart failure, and subsequent IC dual runs passed with a different order.

`OrderedDescribe` prevents Ginkgo from shuffling the specs even when `--randomize-all` is enabled, preserving the declared state transition order.

## Validation

- `python3 -m unittest hack.test_e2e_selector`
- `go test ./test/e2e/ovn-ic -run '^$'`\n- `CI=true make lint` (`golangci-lint`: 0 issues; modernize passed)\n- `git diff --check`\n\nFixes the ordering race observed in https://github.com/kubeovn/kube-ovn/actions/runs/34709224263/job/103597197327.