### PR TITLE
fix(daemon): flush nftables chains before deleting them

### DIFF
--- a/pkg/daemon/gateway_nft_linux.go
+++ b/pkg/daemon/gateway_nft_linux.go
@@ -1037,6 +1037,8 @@ func (b *nftGatewayBackend) renderAuditRepair(ctx context.Context, desired gatew
 
 		for _, name := range objects["chain"] {
 			tx.Flush(&knftables.Chain{Family: family.Family, Table: table, Name: name})
+		}
+		for _, name := range objects["chain"] {
 			tx.Delete(&knftables.Chain{Family: family.Family, Table: table, Name: name})
 		}
 		for _, name := range objects["set"] {

--- a/pkg/daemon/gateway_nft_linux_test.go
+++ b/pkg/daemon/gateway_nft_linux_test.go
@@ -435,6 +435,34 @@ func TestNFTAuditRepairsObjectDefinitionDrift(t *testing.T) {
 	require.Equal(t, before+1, testutil.ToFloat64(metricGatewayNFTRepairs))
 }
 
+func TestNFTAuditFlushesChainReferencesBeforeDeletingChains(t *testing.T) {
+	fake := knftables.NewFake("", "")
+	reader := &orderedNFTReader{
+		Interface: fake,
+		objects: map[string][]string{
+			"chain": {"nat-policy", "nat-postrouting"},
+		},
+	}
+	backend := &nftGatewayBackend{
+		writer:  fake,
+		readers: map[knftables.Family]knftables.Interface{knftables.IPv6Family: reader},
+	}
+	desired := gatewayNFTSnapshot{Families: []nftFamilySnapshot{{
+		Family: knftables.IPv6Family,
+		Table:  nftGatewayTable,
+	}}}
+
+	tx, repaired, err := backend.renderAuditRepair(t.Context(), desired)
+	require.NoError(t, err)
+	require.True(t, repaired)
+	dump := tx.String()
+	policyDelete := strings.Index(dump, "delete chain ip6 kube-ovn nat-policy")
+	postroutingFlush := strings.Index(dump, "flush chain ip6 kube-ovn nat-postrouting")
+	require.NotEqual(t, -1, policyDelete)
+	require.NotEqual(t, -1, postroutingFlush)
+	require.Less(t, postroutingFlush, policyDelete)
+}
+
 func TestParseNFTDefinitions(t *testing.T) {
 	data := []byte(`{"nftables":[
 		{"set":{"name":"subnets","type":"ipv4_addr","flags":["interval"]}},
@@ -533,6 +561,15 @@ func TestNFTCleanupBothFamilies(t *testing.T) {
 type failingNFTInterface struct {
 	knftables.Interface
 	fail bool
+}
+
+type orderedNFTReader struct {
+	knftables.Interface
+	objects map[string][]string
+}
+
+func (r *orderedNFTReader) ListAll(context.Context) (map[string][]string, error) {
+	return r.objects, nil
 }
 
 func (f *failingNFTInterface) Run(ctx context.Context, tx *knftables.Transaction) error {


### PR DESCRIPTION
## Summary

- flush every existing nftables chain before deleting any chain during audit repair
- add a regression test for referenced chain deletion order

## Root cause

Job [103661903998](https://github.com/kubeovn/kube-ovn/actions/runs/34733056310/job/103661903998) failed the IPv6 overlay conformance test `should support http and tcp readiness probe in custom vpc pod`. The daemon repeatedly failed its nftables audit transaction with `Device or resource busy` while deleting the referenced `ip6 kube-ovn nat-policy` chain before flushing `nat-postrouting`. The gateway reconciliation therefore never installed the TProxy rules.

## Validation

- `go test ./pkg/daemon -count=1`
- `go test ./test/e2e/framework/iptables -count=1`
- `git diff --check`

Fixes the transaction ordering without changing the desired nftables schema.